### PR TITLE
Allow the abilility to preload aggregate methods on an association

### DIFF
--- a/lib/jit_preloader/active_record/base.rb
+++ b/lib/jit_preloader/active_record/base.rb
@@ -5,10 +5,43 @@ module JitPreloadExtension
   included do
     attr_accessor :jit_preloader
     attr_accessor :jit_n_plus_one_tracking
+    attr_accessor :jit_preload_aggregates
   end
 
   class_methods do
     delegate :jit_preload, to: :all
+
+    def has_many_aggregate(assoc, name, aggregate, field, default: 0)
+      define_method("#{assoc}_#{name}") do
+        self.jit_preload_aggregates ||= {}
+        return jit_preload_aggregates[aggregate] if jit_preload_aggregates[aggregate]
+        if jit_preloader
+          reflection = association(assoc).reflection
+          primary_ids = jit_preloader.records.collect{|r| r[reflection.active_record_primary_key] }
+          klass = reflection.klass
+
+          preloaded_data = Hash[klass
+                                 .where(reflection.foreign_key => primary_ids)
+                                 .group(reflection.foreign_key)
+                                 .send(aggregate, field)
+                               ]
+
+          jit_preloader.records.each do |record|
+            record.jit_preload_aggregates ||= {}
+            record.jit_preload_aggregates[aggregate] = preloaded_data[record.id] || default
+          end
+        else
+          self.jit_preload_aggregates[aggregate] = send(assoc).send(aggregate, field) || default
+        end
+        jit_preload_aggregates[aggregate]
+      end
+
+      def reload(*args)
+        self.jit_preload_aggregates = {}
+        super
+      end
+
+    end
   end
 end
 

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -1,6 +1,9 @@
 class Contact < ActiveRecord::Base
   has_many :addresses
   has_one :email_address
+
+  has_many_aggregate :addresses, :max_street_length, :maximum, "LENGTH(street)"
+  has_many_aggregate :addresses, :count, :count, "*"
 end
 
 class Address < ActiveRecord::Base


### PR DESCRIPTION
Add the ability to preload an aggregate method on associations. 

This will let you do a just in time preload of an association count, or a maximum, or a sum, etc. 


