### PR TITLE
Bug Fixes from 0.0.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jit_preloader (0.0.3)
+    jit_preloader (0.0.6)
       activerecord (~> 4.2)
       activesupport
 
@@ -28,7 +28,7 @@ GEM
     diff-lcs (1.2.5)
     i18n (0.7.0)
     json (1.8.3)
-    minitest (5.9.1)
+    minitest (5.10.1)
     rake (10.5.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -59,3 +59,6 @@ DEPENDENCIES
   rake (~> 10.0)
   rspec
   sqlite3
+
+BUNDLED WITH
+   1.13.6

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ end
 #new
 class Contact < ActiveRecord::Bas
   has_many :addresses
-  has_many_aggregate :addresses, :max_street_length, :maximum, "LENGTH(street)"
+  has_many_aggregate :addresses, :max_street_length, :maximum, "LENGTH(street)", default: nil
   has_many_aggregate :addresses, :count_all, :count, "*"
 end
 

--- a/lib/jit_preloader/version.rb
+++ b/lib/jit_preloader/version.rb
@@ -1,3 +1,3 @@
 module JitPreloader
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end


### PR DESCRIPTION
Allow nil to be a default. 

If the association has a provided scope, we need to execute that so we don't silently drop extra conditions