### PR TITLE
Ensure that we dup the array that we attach to the preloader so that …

### DIFF
--- a/lib/jit_preloader/preloader.rb
+++ b/lib/jit_preloader/preloader.rb
@@ -5,7 +5,7 @@ module JitPreloader
 
     def self.attach(records)
       new.tap do |loader|
-        loader.records = records
+        loader.records = records.dup
         records.each do |record|
           record.jit_preloader = loader
         end
@@ -21,7 +21,7 @@ module JitPreloader
 
     # We do not want the jit_preloader to be dumpable
     # If you dump a ActiveRecord::Base object that has a jit_preloader instance variable
-    # you will also end up dumping all of the records the preloader has reference to. 
+    # you will also end up dumping all of the records the preloader has reference to.
     # Imagine getting N objects from a query and dumping each one of those into a cache
     # each object would dump N+1 objects which means you'll end up storing O(N^2) memory. Thats no good.
     # So instead, we will just nullify the jit_preloader on load

--- a/spec/lib/jit_preloader/preloader_spec.rb
+++ b/spec/lib/jit_preloader/preloader_spec.rb
@@ -93,6 +93,12 @@ RSpec.describe JitPreloader::Preloader do
       example.run
       JitPreloader.globally_enabled = false
     end
+    it "doesn't reference the same records array that is returned" do
+      contacts = Contact.all.to_a
+      contacts << "A string"
+      expect(contacts.first.jit_preloader.records).to eql Contact.all.to_a
+    end
+
     context "when grabbing all of the address'es contries and email addresses" do
       it "doesn't generate an N+1 query ntoification" do
         ActiveSupport::Notifications.subscribed(callback, "n_plus_one_query") do


### PR DESCRIPTION
…we don't pick up any mutations that happen to the array afterwards