### PR TITLE
Issue 6

### DIFF
--- a/lib/jit_preloader/active_record/base.rb
+++ b/lib/jit_preloader/active_record/base.rb
@@ -8,9 +8,18 @@ module JitPreloadExtension
     attr_accessor :jit_preload_aggregates
 
     def reload(*args)
-      self.jit_preload_aggregates = {}
+      clear_jit_preloader!
       super
     end
+
+    def clear_jit_preloader!
+      self.jit_preload_aggregates = {}
+      if jit_preloader
+        jit_preloader.records.delete(self)
+        self.jit_preloader = nil
+      end
+    end
+
   end
 
   class_methods do


### PR DESCRIPTION
https://github.com/clio/jit_preloader/issues/6

Add a public method that clears the jit_preloader aggregation cache as well as clearing the jit_preload record.

This will allow users to explicitly clear the aggregation memoization if they need it to change. This could be useful for testing since the
aggregation can be called, the underlying data can be changed, and the aggregation can be called again.