### PR TITLE
Adding ability to use in addition to hash conditions for the `where` …

### DIFF
--- a/spec/lib/jit_preloader/preloader_spec.rb
+++ b/spec/lib/jit_preloader/preloader_spec.rb
@@ -82,6 +82,12 @@ RSpec.describe JitPreloader::Preloader do
           expect(c.addresses_count(country: canada)).to eql can_addresses_counts[i]
         end
       end
+
+      it "can handle strings for queries" do
+        Contact.jit_preload.each_with_index do |c, i|
+          expect(c.addresses_count("contact_id IS NOT NULL")).to eql(usa_addresses_counts[i] + can_addresses_counts[i])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
…method when getting preloaded data in the base association class

## What does this do?

This changes the gem to be able to accept strings in the "where" condition of an aggregate association. Usage would be something like it is defined in the specs:

```
Contact.jit_preload.each do |c|
  puts c.addresses_count("contact_id IS NOT NULL")
end
```

## Can this fail?
If a user doesn't supply a string for Conditions, the default value is a hash anyway.