### PR TITLE
Add support for polymorphic associations for has_many_aggregate

### DIFF
--- a/lib/jit_preloader/active_record/base.rb
+++ b/lib/jit_preloader/active_record/base.rb
@@ -43,6 +43,10 @@ module JitPreloadExtension
 
           conditions[reflection.foreign_key] = primary_ids
 
+          if reflection.type.present?
+            conditions[reflection.type] = self.class.name
+          end
+
           preloaded_data = Hash[association_scope
                                  .where(conditions)
                                  .group(reflection.foreign_key)

--- a/spec/lib/jit_preloader/preloader_spec.rb
+++ b/spec/lib/jit_preloader/preloader_spec.rb
@@ -32,12 +32,50 @@ RSpec.describe JitPreloader::Preloader do
     )
   end
 
+  let!(:contact_owner) do
+    ContactOwner.create(
+      contacts: [contact1, contact2],
+    )
+  end
+
   let(:canada) { Country.create(name: "Canada") }
   let(:usa) { Country.create(name: "U.S.A") }
 
   let(:source_map) { Hash.new{|h,k| h[k]= Array.new } }
   let(:callback) do
     ->(event, data){ source_map[data[:source]] << data[:association] }
+  end
+
+  context "when preloading an aggregate as polymorphic" do
+    let(:contact_owner_counts) { [2] }
+
+    context "without jit preload" do
+      it "generates N+1 query notifications for each one" do
+        ActiveSupport::Notifications.subscribed(callback, "n_plus_one_query") do
+          ContactOwner.all.each_with_index do |c, i|
+            expect(c.contacts_count).to eql contact_owner_counts[i]
+          end
+        end
+
+        contact_owner_queries = [contact_owner].product([["contacts.count"]])
+        expect(source_map).to eql(Hash[contact_owner_queries])
+      end
+    end
+
+    context "with jit_preload" do
+      let(:usa_addresses_counts) { [2, 0, 1] }
+      let(:can_addresses_counts) { [1, 0, 1] }
+
+      it "does NOT generate N+1 query notifications" do
+        ActiveSupport::Notifications.subscribed(callback, "n_plus_one_query") do
+          ContactOwner.jit_preload.each_with_index do |c, i|
+            expect(c.contacts_count).to eql contact_owner_counts[i]
+          end
+        end
+
+        expect(source_map).to eql({})
+      end
+    end
   end
 
   context "when preloading an aggregate" do

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -1,7 +1,8 @@
 class Database
   def self.tables
     [
-      "CREATE TABLE contacts (id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(255))",
+      "CREATE TABLE contacts (id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(255), contact_owner_id INTEGER, contact_owner_type VARCHAR(255))",
+      "CREATE TABLE contact_owners (id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(255))",
       "CREATE TABLE addresses (id INTEGER NOT NULL PRIMARY KEY, contact_id INTEGER NOT NULL, country_id INTEGER NOT NULL, street VARCHAR(255))",
       "CREATE TABLE email_addresses (id INTEGER NOT NULL PRIMARY KEY, contact_id INTEGER NOT NULL, address VARCHAR(255))",
       "CREATE TABLE phone_numbers (id INTEGER NOT NULL PRIMARY KEY, contact_id INTEGER NOT NULL, phone VARCHAR(10))",

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -1,7 +1,10 @@
 class Contact < ActiveRecord::Base
+  belongs_to :contact_owner, polymorphic: true
+
   has_many :addresses
   has_many :phone_numbers
   has_one :email_address
+
 
   has_many_aggregate :addresses, :max_street_length, :maximum, "LENGTH(street)"
   has_many_aggregate :phone_numbers, :count, :count, "id"
@@ -23,4 +26,9 @@ end
 
 class Country < ActiveRecord::Base
   has_many :addresses
+end
+
+class ContactOwner < ActiveRecord::Base
+  has_many :contacts, as: :contact_owner
+  has_many_aggregate :contacts, :count, :count, "*"
 end


### PR DESCRIPTION
This adds support for has_many_aggregate against polymorphic associations.  Previously the query lacked a where condition on the polymorphic type and so would give bad counts with polymorphic associations with multiple types on the other end of the association.