### PR TITLE
Feature has_many_aggregate on a through relationship.

### DIFF
--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -5,7 +5,6 @@ class Contact < ActiveRecord::Base
   has_many :phone_numbers
   has_one :email_address
 
-
   has_many_aggregate :addresses, :max_street_length, :maximum, "LENGTH(street)"
   has_many_aggregate :phone_numbers, :count, :count, "id"
   has_many_aggregate :addresses, :count, :count, "*"
@@ -26,9 +25,17 @@ end
 
 class Country < ActiveRecord::Base
   has_many :addresses
+  has_many :contacts, through: :addresses
+  has_many :contact_owners, through: :contacts, source_type: 'ContactOwner'
+
+  has_many_aggregate :contacts, :count, :count, "*"
+  has_many_aggregate :contact_owners, :count, :count, "*"
 end
 
 class ContactOwner < ActiveRecord::Base
   has_many :contacts, as: :contact_owner
+  has_many :addresses, through: :contacts
+
   has_many_aggregate :contacts, :count, :count, "*"
+  has_many_aggregate :addresses, :count, :count, "*"
 end


### PR DESCRIPTION
This adds support for has_many_aggregate on through relationships. Currently, the SQL generated is invalid because the query is missing a join and some conditionals. The specs that were added fail on the master branch but pass with the new functionality.