### PR TITLE
Use prepend instead of include to patch ActiveRecord::Base

### DIFF
--- a/lib/jit_preloader/active_record/base.rb
+++ b/lib/jit_preloader/active_record/base.rb
@@ -1,74 +1,70 @@
 module JitPreloadExtension
+  attr_accessor :jit_preloader
+  attr_accessor :jit_n_plus_one_tracking
+  attr_accessor :jit_preload_aggregates
 
-  extend ActiveSupport::Concern
-
-  included do
-    attr_accessor :jit_preloader
-    attr_accessor :jit_n_plus_one_tracking
-    attr_accessor :jit_preload_aggregates
-
-    def reload(*args)
-      clear_jit_preloader!
-      super
-    end
-
-    def clear_jit_preloader!
-      self.jit_preload_aggregates = {}
-      if jit_preloader
-        jit_preloader.records.delete(self)
-        self.jit_preloader = nil
-      end
-    end
-
+  def reload(*args)
+    clear_jit_preloader!
+    super
   end
 
-  class_methods do
-    delegate :jit_preload, to: :all
+  def clear_jit_preloader!
+    self.jit_preload_aggregates = {}
+    if jit_preloader
+      jit_preloader.records.delete(self)
+      self.jit_preloader = nil
+    end
+  end
 
-    def has_many_aggregate(assoc, name, aggregate, field, default: 0)
-      method_name = "#{assoc}_#{name}"
+  def self.prepended(base)
+    class << base
+      delegate :jit_preload, to: :all
 
-      define_method(method_name) do |conditions={}|
-        self.jit_preload_aggregates ||= {}
+      def has_many_aggregate(assoc, name, aggregate, field, default: 0)
+        method_name = "#{assoc}_#{name}"
 
-        key = "#{method_name}|#{conditions.sort.hash}"
-        return jit_preload_aggregates[key] if jit_preload_aggregates.key?(key)
-        if jit_preloader
-          reflection = association(assoc).reflection
-          primary_ids = jit_preloader.records.collect{|r| r[reflection.active_record_primary_key] }
-          klass = reflection.klass
+        define_method(method_name) do |conditions={}|
+          self.jit_preload_aggregates ||= {}
 
-          aggregate_association = reflection
-          while aggregate_association.through_reflection
-            aggregate_association = aggregate_association.through_reflection
+          key = "#{method_name}|#{conditions.sort.hash}"
+          return jit_preload_aggregates[key] if jit_preload_aggregates.key?(key)
+          if jit_preloader
+            reflection = association(assoc).reflection
+            primary_ids = jit_preloader.records.collect{|r| r[reflection.active_record_primary_key] }
+            klass = reflection.klass
+
+            aggregate_association = reflection
+            while aggregate_association.through_reflection
+              aggregate_association = aggregate_association.through_reflection
+            end
+
+            association_scope = klass.all.merge(association(assoc).scope).unscope(where: aggregate_association.foreign_key)
+            association_scope = association_scope.instance_exec(&reflection.scope).reorder(nil) if reflection.scope
+
+            conditions[aggregate_association.table_name] = { aggregate_association.foreign_key => primary_ids }
+            if reflection.type.present?
+              conditions[reflection.type] = self.class.name
+            end
+            group_by = "#{aggregate_association.table_name}.#{aggregate_association.foreign_key}"
+
+            preloaded_data = Hash[association_scope
+              .where(conditions)
+              .group(group_by)
+              .send(aggregate, field)
+            ]
+
+            jit_preloader.records.each do |record|
+              record.jit_preload_aggregates ||= {}
+              record.jit_preload_aggregates[key] = preloaded_data[record.id] || default
+            end
+          else
+            self.jit_preload_aggregates[key] = send(assoc).where(conditions).send(aggregate, field) || default
           end
-
-          association_scope = klass.all.merge(association(assoc).scope).unscope(where: aggregate_association.foreign_key)
-          association_scope = association_scope.instance_exec(&reflection.scope).reorder(nil) if reflection.scope
-
-          conditions[aggregate_association.table_name] = { aggregate_association.foreign_key => primary_ids }
-          if reflection.type.present?
-            conditions[reflection.type] = self.class.name
-          end
-          group_by = "#{aggregate_association.table_name}.#{aggregate_association.foreign_key}"
-
-          preloaded_data = Hash[association_scope
-            .where(conditions)
-            .group(group_by)
-            .send(aggregate, field)
-          ]
-
-          jit_preloader.records.each do |record|
-            record.jit_preload_aggregates ||= {}
-            record.jit_preload_aggregates[key] = preloaded_data[record.id] || default
-          end
-        else
-          self.jit_preload_aggregates[key] = send(assoc).where(conditions).send(aggregate, field) || default
+          jit_preload_aggregates[key]
         end
-        jit_preload_aggregates[key]
       end
     end
   end
 end
 
-ActiveRecord::Base.send(:include, JitPreloadExtension)
+ActiveRecord::Base.send(:prepend, JitPreloadExtension)

--- a/lib/jit_preloader/version.rb
+++ b/lib/jit_preloader/version.rb
@@ -1,3 +1,3 @@
 module JitPreloader
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end


### PR DESCRIPTION
The current approach to inject the functionality is to `include` a module which can have the affect of clobbering patches from other gems. `prepend` is a better approach, however it can still have issues with alias chains https://bugs.ruby-lang.org/issues/11120

A concrete example:

We ran into issues with this gem along side https://github.com/attr-encrypted/attr_encrypted which uses alias method chains. The solution is to ensure that any gem that uses alias chains is loaded first then gems which prepend.

Implementation:

ActiveSupport::Concern is built to be used with `include` not `prepend` so we need to use the `prepended` hook to add class methods and there is no reason to use ActiveSupport concern anymore.