### PR TITLE
Add support for has_many_aggregate when working with STI models

### DIFF
--- a/lib/jit_preloader/active_record/base.rb
+++ b/lib/jit_preloader/active_record/base.rb
@@ -49,8 +49,9 @@ module JitPreloadExtension
             # doesn't include results from other child models
             is_base_class = aggregate_association.klass.superclass.abstract_class? || aggregate_association.klass.superclass == ActiveRecord::Base
             has_type_column = aggregate_association.klass.column_names.include?(aggregate_association.klass.inheritance_column)
-            if is_child_sti_model = !is_base_class && has_type_column
-              conditions[table_alias_name].merge!({ type: aggregate_association.klass.sti_name })
+            is_child_sti_model = !is_base_class && has_type_column
+            if is_child_sti_model
+              conditions[table_alias_name].merge!({ aggregate_association.klass.inheritance_column => aggregate_association.klass.sti_name })
             end
 
             if reflection.type.present?

--- a/lib/jit_preloader/active_record/base.rb
+++ b/lib/jit_preloader/active_record/base.rb
@@ -49,9 +49,9 @@ module JitPreloadExtension
 
             # If the association is a STI child model, specify its type in the condition so that it
             # doesn't include results from other child models
-            is_base_class = aggregate_association.klass.superclass.abstract_class? || aggregate_association.klass.superclass == ActiveRecord::Base
+            parent_is_base_class = aggregate_association.klass.superclass.abstract_class? || aggregate_association.klass.superclass == ActiveRecord::Base
             has_type_column = aggregate_association.klass.column_names.include?(aggregate_association.klass.inheritance_column)
-            is_child_sti_model = !is_base_class && has_type_column
+            is_child_sti_model = !parent_is_base_class && has_type_column
             if is_child_sti_model
               conditions[table_reference].merge!({ aggregate_association.klass.inheritance_column => aggregate_association.klass.sti_name })
             end

--- a/lib/jit_preloader/active_record/base.rb
+++ b/lib/jit_preloader/active_record/base.rb
@@ -41,15 +41,18 @@ module JitPreloadExtension
             association_scope = klass.all.merge(association(assoc).scope).unscope(where: aggregate_association.foreign_key)
             association_scope = association_scope.instance_exec(&reflection.scope).reorder(nil) if reflection.scope
 
+            # If the query uses an alias for the association, use that instead of the table name
             table_alias_name = association_scope.references_values.first || aggregate_association.table_name
             conditions[table_alias_name] = { aggregate_association.foreign_key => primary_ids }
 
+            # If the association is a STI child model, specify its type in the condition so that it
+            # doesn't include results from other child models
             is_base_class = aggregate_association.klass.superclass.abstract_class? || aggregate_association.klass.superclass == ActiveRecord::Base
             has_type_column = aggregate_association.klass.column_names.include?(aggregate_association.klass.inheritance_column)
             if is_child_sti_model = !is_base_class && has_type_column
               conditions[table_alias_name].merge!({ type: aggregate_association.klass.sti_name })
             end
-            
+
             if reflection.type.present?
               conditions[reflection.type] = self.class.name
             end

--- a/lib/jit_preloader/version.rb
+++ b/lib/jit_preloader/version.rb
@@ -1,3 +1,3 @@
 module JitPreloader
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/spec/lib/jit_preloader/preloader_spec.rb
+++ b/spec/lib/jit_preloader/preloader_spec.rb
@@ -49,21 +49,11 @@ RSpec.describe JitPreloader::Preloader do
   end
 
   context "for single table inheritance" do
-    let!(:contact_book) { ContactBook.create(name: "The Yellow Pages") }
-    let!(:contact) { Contact.create(name: "Contact", contact_book: contact_book) }
-    let!(:company1) { Company.create(name: "Company1", contact_book: contact_book) }
-    let!(:company2) { Company.create(name: "Company2", contact_book: contact_book) }
-    let!(:contact_employee1) { Employee.create(name: "Contact Employee1", contact: contact) }
-    let!(:contact_employee2) { Employee.create(name: "Contact Employee2", contact: contact) }
-    let!(:company_employee1) { Employee.create(name: "Company Employee1", contact: company1) }
-    let!(:company_employee2) { Employee.create(name: "Company Employee2", contact: company2) }
-    let!(:child1) { Child.create(name: "Child1") }
-    let!(:child2) { Child.create(name: "Child2") }
-    let!(:child3) { Child.create(name: "Child3") }
-    let!(:parent1) { Parent.create(name: "Parent1", contact_book: contact_book, children: [child1, child2]) }
-    let!(:parent2) { Parent.create(name: "Parent2", contact_book: contact_book, children: [child2, child3]) }
-
     context "when preloading an aggregate for a child model" do
+      let!(:contact_book) { ContactBook.create(name: "The Yellow Pages") }
+      let!(:company1) { Company.create(name: "Company1", contact_book: contact_book) }
+      let!(:company2) { Company.create(name: "Company2", contact_book: contact_book) }
+
       it "can handle queries" do
         contact_books = ContactBook.jit_preload.to_a
         expect(contact_books.first.companies_count).to eq 2
@@ -71,6 +61,15 @@ RSpec.describe JitPreloader::Preloader do
     end
 
     context "when preloading an aggregate of a child model through its base model" do
+      let!(:contact_book) { ContactBook.create(name: "The Yellow Pages") }
+      let!(:contact) { Contact.create(name: "Contact", contact_book: contact_book) }
+      let!(:company1) { Company.create(name: "Company1", contact_book: contact_book) }
+      let!(:company2) { Company.create(name: "Company2", contact_book: contact_book) }
+      let!(:contact_employee1) { Employee.create(name: "Contact Employee1", contact: contact) }
+      let!(:contact_employee2) { Employee.create(name: "Contact Employee2", contact: contact) }
+      let!(:company_employee1) { Employee.create(name: "Company Employee1", contact: company1) }
+      let!(:company_employee2) { Employee.create(name: "Company Employee2", contact: company2) }
+
       it "can handle queries" do
         contact_books = ContactBook.jit_preload.to_a
         expect(contact_books.first.employees_count).to eq 4
@@ -78,6 +77,15 @@ RSpec.describe JitPreloader::Preloader do
     end
 
     context "when preloading an aggregate of a nested child model through another child model" do
+      let!(:contact_book) { ContactBook.create(name: "The Yellow Pages") }
+      let!(:contact) { Contact.create(name: "Contact", contact_book: contact_book) }
+      let!(:company1) { Company.create(name: "Company1", contact_book: contact_book) }
+      let!(:company2) { Company.create(name: "Company2", contact_book: contact_book) }
+      let!(:contact_employee1) { Employee.create(name: "Contact Employee1", contact: contact) }
+      let!(:contact_employee2) { Employee.create(name: "Contact Employee2", contact: contact) }
+      let!(:company_employee1) { Employee.create(name: "Company Employee1", contact: company1) }
+      let!(:company_employee2) { Employee.create(name: "Company Employee2", contact: company2) }
+
       it "can handle queries" do
         contact_books = ContactBook.jit_preload.to_a
         expect(contact_books.first.company_employees_count).to eq 2
@@ -85,6 +93,13 @@ RSpec.describe JitPreloader::Preloader do
     end
 
     context "when preloading an aggregate of a nested child model through a many-to-many relationship with another child model" do
+      let!(:contact_book) { ContactBook.create(name: "The Yellow Pages") }
+      let!(:child1) { Child.create(name: "Child1") }
+      let!(:child2) { Child.create(name: "Child2") }
+      let!(:child3) { Child.create(name: "Child3") }
+      let!(:parent1) { Parent.create(name: "Parent1", contact_book: contact_book, children: [child1, child2]) }
+      let!(:parent2) { Parent.create(name: "Parent2", contact_book: contact_book, children: [child2, child3]) }
+
       it "can handle queries" do
         contact_books = ContactBook.jit_preload.to_a
         expect(contact_books.first.children_count).to eq 4

--- a/spec/lib/jit_preloader/preloader_spec.rb
+++ b/spec/lib/jit_preloader/preloader_spec.rb
@@ -2,6 +2,26 @@ require 'spec_helper'
 
 RSpec.describe JitPreloader::Preloader do
 
+  let!(:book) { Book.create(name: "Lord of the Rings") }
+
+  let!(:section) { Section.create(name: "Main", book: book) }
+  let!(:sub_section1) { SubSection.create(name: "Chapter 1", section: section) }
+  let!(:sub_section2) { SubSection.create(name: "Chapter 2", section: section) }
+
+  let!(:endorsement) { Endorsement.create(name: "Endorsement", book: book) }
+  let!(:endorsement_section1) { SubSection.create(name: "Endorsement 1", section: endorsement) }
+  let!(:endorsement_section2) { SubSection.create(name: "Endorsement 2", section: endorsement) }
+
+  it do
+    books = Book.jit_preload.to_a
+    expect(books.first.sub_sections_count).to eq 4
+  end
+
+  it do
+    books = Book.jit_preload.to_a
+    expect(books.first.endorsement_sub_sections_count).to eq 2
+  end
+
   let!(:contact1) do
     addresses = [
       Address.new(street: "123 Fake st", country: canada),

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -2,14 +2,12 @@ class Database
   def self.tables
     [
       "CREATE TABLE contact_books (id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(255))",
-      "CREATE TABLE contacts (id INTEGER NOT NULL PRIMARY KEY, contact_book_id INTEGER, contact_id INTEGER, name VARCHAR(255), contact_owner_id INTEGER, contact_owner_type VARCHAR(255))",
+      "CREATE TABLE contacts (id INTEGER NOT NULL PRIMARY KEY, type VARCHAR(255), contact_book_id INTEGER, contact_id INTEGER, name VARCHAR(255), contact_owner_id INTEGER, contact_owner_type VARCHAR(255))",
       "CREATE TABLE contact_owners (id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(255))",
       "CREATE TABLE addresses (id INTEGER NOT NULL PRIMARY KEY, contact_id INTEGER NOT NULL, country_id INTEGER NOT NULL, street VARCHAR(255))",
       "CREATE TABLE email_addresses (id INTEGER NOT NULL PRIMARY KEY, contact_id INTEGER NOT NULL, address VARCHAR(255))",
       "CREATE TABLE phone_numbers (id INTEGER NOT NULL PRIMARY KEY, contact_id INTEGER NOT NULL, phone VARCHAR(10))",
       "CREATE TABLE countries (id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(255))",
-      "CREATE TABLE books (id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(255))",
-      "CREATE TABLE sections (id INTEGER NOT NULL PRIMARY KEY, type VARCHAR(255), book_id INTEGER, section_id INTEGER, name VARCHAR(255))",
       "CREATE TABLE parents_children (id INTEGER NOT NULL PRIMARY KEY, parent_id INTEGER, child_id INTEGER)",
     ]
   end

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -1,7 +1,8 @@
 class Database
   def self.tables
     [
-      "CREATE TABLE contacts (id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(255), contact_owner_id INTEGER, contact_owner_type VARCHAR(255))",
+      "CREATE TABLE contact_books (id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(255))",
+      "CREATE TABLE contacts (id INTEGER NOT NULL PRIMARY KEY, contact_book_id INTEGER, contact_id INTEGER, name VARCHAR(255), contact_owner_id INTEGER, contact_owner_type VARCHAR(255))",
       "CREATE TABLE contact_owners (id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(255))",
       "CREATE TABLE addresses (id INTEGER NOT NULL PRIMARY KEY, contact_id INTEGER NOT NULL, country_id INTEGER NOT NULL, street VARCHAR(255))",
       "CREATE TABLE email_addresses (id INTEGER NOT NULL PRIMARY KEY, contact_id INTEGER NOT NULL, address VARCHAR(255))",
@@ -9,6 +10,7 @@ class Database
       "CREATE TABLE countries (id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(255))",
       "CREATE TABLE books (id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(255))",
       "CREATE TABLE sections (id INTEGER NOT NULL PRIMARY KEY, type VARCHAR(255), book_id INTEGER, section_id INTEGER, name VARCHAR(255))",
+      "CREATE TABLE parents_children (id INTEGER NOT NULL PRIMARY KEY, parent_id INTEGER, child_id INTEGER)",
     ]
   end
 

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -7,6 +7,8 @@ class Database
       "CREATE TABLE email_addresses (id INTEGER NOT NULL PRIMARY KEY, contact_id INTEGER NOT NULL, address VARCHAR(255))",
       "CREATE TABLE phone_numbers (id INTEGER NOT NULL PRIMARY KEY, contact_id INTEGER NOT NULL, phone VARCHAR(10))",
       "CREATE TABLE countries (id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(255))",
+      "CREATE TABLE books (id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(255))",
+      "CREATE TABLE sections (id INTEGER NOT NULL PRIMARY KEY, type VARCHAR(255), book_id INTEGER, section_id INTEGER, name VARCHAR(255))",
     ]
   end
 

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -8,6 +8,7 @@ class ContactBook < ActiveRecord::Base
   has_many :parents
   has_many :children, through: :parents
 
+  has_many_aggregate :companies, :count, :count, "*"
   has_many_aggregate :employees, :count, :count, "*"
   has_many_aggregate :company_employees, :count, :count, "*"
   has_many_aggregate :children, :count, :count, "*"
@@ -77,27 +78,4 @@ class ContactOwner < ActiveRecord::Base
 
   has_many_aggregate :contacts, :count, :count, "*"
   has_many_aggregate :addresses, :count, :count, "*"
-end
-
-class Book < ActiveRecord::Base
-  has_many :sections
-  has_many :sub_sections, through: :sections
-
-  has_many :endorsements
-  has_many :endorsement_sub_sections, through: :endorsements, source: :sub_sections
-
-  has_many_aggregate :sub_sections, :count, :count, "*"
-  has_many_aggregate :endorsement_sub_sections, :count, :count, "*"
-end
-
-class Section < ActiveRecord::Base
-  belongs_to :book
-  has_many :sub_sections
-end
-
-class Endorsement < Section
-end
-
-class SubSection < Section
-  belongs_to :section
 end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -1,22 +1,52 @@
+class ContactBook < ActiveRecord::Base
+  has_many :contacts
+  has_many :employees, through: :contacts
+
+  has_many :companies
+  has_many :company_employees, through: :companies, source: :employees
+
+  has_many :parents
+  has_many :children, through: :parents
+
+  has_many_aggregate :employees, :count, :count, "*"
+  has_many_aggregate :company_employees, :count, :count, "*"
+  has_many_aggregate :children, :count, :count, "*"
+end
+
 class Contact < ActiveRecord::Base
+  belongs_to :contact_book
   belongs_to :contact_owner, polymorphic: true
 
   has_many :addresses
   has_many :phone_numbers
   has_one :email_address
+  has_many :employees
 
   has_many_aggregate :addresses, :max_street_length, :maximum, "LENGTH(street)"
   has_many_aggregate :phone_numbers, :count, :count, "id"
   has_many_aggregate :addresses, :count, :count, "*"
 end
 
-class Author < Contact
-  belongs_to :book
-  has_many :reviewers
+class Company < Contact
 end
 
-class Reviewer < Contact
-  belongs_to :author
+class Employee < Contact
+  belongs_to :contact
+end
+
+class ParentsChild < ActiveRecord::Base
+  belongs_to :parent
+  belongs_to :child
+end
+
+class Parent < Contact
+  has_many :parents_child
+  has_many :children, through: :parents_child
+end
+
+class Child < Contact
+  has_many :parents_child
+  has_many :parents, through: :parents_child
 end
 
 class Address < ActiveRecord::Base

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -10,6 +10,15 @@ class Contact < ActiveRecord::Base
   has_many_aggregate :addresses, :count, :count, "*"
 end
 
+class Author < Contact
+  belongs_to :book
+  has_many :reviewers
+end
+
+class Reviewer < Contact
+  belongs_to :author
+end
+
 class Address < ActiveRecord::Base
   belongs_to :contact
   belongs_to :country
@@ -38,4 +47,27 @@ class ContactOwner < ActiveRecord::Base
 
   has_many_aggregate :contacts, :count, :count, "*"
   has_many_aggregate :addresses, :count, :count, "*"
+end
+
+class Book < ActiveRecord::Base
+  has_many :sections
+  has_many :sub_sections, through: :sections
+
+  has_many :endorsements
+  has_many :endorsement_sub_sections, through: :endorsements, source: :sub_sections
+
+  has_many_aggregate :sub_sections, :count, :count, "*"
+  has_many_aggregate :endorsement_sub_sections, :count, :count, "*"
+end
+
+class Section < ActiveRecord::Base
+  belongs_to :book
+  has_many :sub_sections
+end
+
+class Endorsement < Section
+end
+
+class SubSection < Section
+  belongs_to :section
 end


### PR DESCRIPTION
When using STI, `has_many_aggregate` to aggregate child models, under certain conditions, will fail to find the existing results. This is because the query uses an alias for the table join (since it's joining to the same table), but the `jit_preloader` logic naively uses the table's name.

These changes add logic to determine when a table alias is present in the query, and when one is, use that for the `jit_preloader` query.

While looking into this issue, we also discovered that the aggregate query fails to limit the results based on type when querying a child model through another child model. These changes also address that issue by including the type condition when querying through a child model.

## Example queries

### Before:
```sql
SELECT COUNT(*) AS count_all, contacts.contact_book_id AS contacts_contact_book_id
FROM "contacts"
INNER JOIN "contacts" "companies_company_employees" ON "contacts"."contact_id" = "companies_company_employees"."id"
WHERE "contacts"."type" IN ('Employee') AND "contacts"."contact_book_id" = ?
GROUP BY contacts.contact_book_id
```

### After:
```sql
SELECT COUNT(*) AS count_all, companies_company_employees.contact_book_id AS companies_company_employees_contact_book_id
FROM "contacts"
INNER JOIN "contacts" "companies_company_employees" ON "contacts"."contact_id" = "companies_company_employees"."id"
WHERE "contacts"."type" IN ('Employee') AND "companies_company_employees"."contact_book_id" = ? AND "companies_company_employees"."type" = ?
GROUP BY companies_company_employees.contact_book_id
```