### PR TITLE
Add method for dynamic loading

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,32 +1,35 @@
 PATH
   remote: .
   specs:
-    jit_preloader (0.2.1)
+    jit_preloader (0.2.3)
       activerecord (> 4.2, < 6)
       activesupport
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.2)
-      activesupport (= 5.2.2)
-    activerecord (5.2.2)
-      activemodel (= 5.2.2)
-      activesupport (= 5.2.2)
+    activemodel (5.2.4.2)
+      activesupport (= 5.2.4.2)
+    activerecord (5.2.4.2)
+      activemodel (= 5.2.4.2)
+      activesupport (= 5.2.4.2)
       arel (>= 9.0)
-    activesupport (5.2.2)
+    activesupport (5.2.4.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (9.0.0)
     byebug (9.0.6)
-    concurrent-ruby (1.1.4)
+    concurrent-ruby (1.1.6)
     database_cleaner (1.5.3)
+    db-query-matchers (0.10.0)
+      activesupport (>= 4.0, < 7)
+      rspec (~> 3.0)
     diff-lcs (1.2.5)
-    i18n (1.6.0)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
-    minitest (5.11.3)
+    minitest (5.14.0)
     rake (13.0.1)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -43,7 +46,7 @@ GEM
     rspec-support (3.5.0)
     sqlite3 (1.3.12)
     thread_safe (0.3.6)
-    tzinfo (1.2.5)
+    tzinfo (1.2.6)
       thread_safe (~> 0.1)
 
 PLATFORMS
@@ -53,6 +56,7 @@ DEPENDENCIES
   bundler
   byebug
   database_cleaner
+  db-query-matchers
   jit_preloader!
   rake (~> 13.0)
   rspec

--- a/jit_preloader.gemspec
+++ b/jit_preloader.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "database_cleaner"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "byebug"
+  spec.add_development_dependency "db-query-matchers"
 end

--- a/lib/jit_preloader/preloader.rb
+++ b/lib/jit_preloader/preloader.rb
@@ -12,38 +12,6 @@ module JitPreloader
       end
     end
 
-    def preload(name, records, associations, preload_scope = nil)
-      wrapped_records       = Array.wrap(records).compact.uniq
-      wrapped_associations  = Array.wrap(associations)
-
-      return if records.empty?
-
-      previous_association_values = Hash.new{|h,k| h[k] = {} }
-      wrapped_associations.flat_map do |association_name|
-        wrapped_records.each do |record|
-          association = record.association(association_name)
-          if association.loaded?
-            previous_association_values[association_name][record] = association.target
-            association.reset
-          end
-        end
-      end
-
-      super(records, associations, preload_scope)
-
-      wrapped_associations.flat_map do |association_name|
-        wrapped_records.each do |record|
-          record.jit_preload_scoped_relations ||= {}
-          association = record.association(association_name)
-          record.jit_preload_scoped_relations[name] = association.target
-          association.reset
-          if previous_association_values[association_name].key?(record)
-            association.target = previous_association_values[association_name][record]
-          end
-        end
-      end
-    end
-
     def jit_preload(association)
       # It is possible that the records array has multiple different classes (think single table inheritance).
       # Thus, it is possible that some of the records don't have an association.

--- a/lib/jit_preloader/preloader.rb
+++ b/lib/jit_preloader/preloader.rb
@@ -12,6 +12,38 @@ module JitPreloader
       end
     end
 
+    def preload(name, records, associations, preload_scope = nil)
+      wrapped_records       = Array.wrap(records).compact.uniq
+      wrapped_associations  = Array.wrap(associations)
+
+      return if records.empty?
+
+      previous_association_values = Hash.new{|h,k| h[k] = {} }
+      wrapped_associations.flat_map do |association_name|
+        wrapped_records.each do |record|
+          association = record.association(association_name)
+          if association.loaded?
+            previous_association_values[association_name][record] = association.target
+            association.reset
+          end
+        end
+      end
+
+      super(records, associations, preload_scope)
+
+      wrapped_associations.flat_map do |association_name|
+        wrapped_records.each do |record|
+          record.jit_preload_scoped_relations ||= {}
+          association = record.association(association_name)
+          record.jit_preload_scoped_relations[name] = association.target
+          association.reset
+          if previous_association_values[association_name].key?(record)
+            association.target = previous_association_values[association_name][record]
+          end
+        end
+      end
+    end
+
     def jit_preload(association)
       # It is possible that the records array has multiple different classes (think single table inheritance).
       # Thus, it is possible that some of the records don't have an association.

--- a/lib/jit_preloader/version.rb
+++ b/lib/jit_preloader/version.rb
@@ -1,3 +1,3 @@
 module JitPreloader
-  VERSION = "0.2.3"
+  VERSION = "0.2.4"
 end

--- a/spec/lib/jit_preloader/active_record/base_spec.rb
+++ b/spec/lib/jit_preloader/active_record/base_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+require "db-query-matchers"
+
+RSpec.describe "ActiveRecord::Base Extensions" do
+
+  let(:canada) { Country.create(name: "Canada") }
+  let(:usa) { Country.create(name: "U.S.A") }
+
+  describe "#preload_scoped_relation" do
+    def call(contact)
+      contact.preload_scoped_relation(
+        name: "American Addresses",
+        base_association: :addresses,
+        preload_scope: Address.where(country: usa)
+      )
+    end
+
+    before do
+      Contact.create(name: "Bar", addresses: [
+        Address.new(street: "123 Fake st", country: canada),
+        Address.new(street: "21 Jump st", country: usa),
+        Address.new(street: "90210 Beverly Hills", country: usa)
+      ])
+
+      Contact.create(name: "Foo", addresses: [
+        Address.new(street: "1 First st", country: canada),
+        Address.new(street: "10 Tenth Ave", country: usa)
+      ])
+    end
+
+    context "when operating on a single object" do
+      it "will load the objects for that object" do
+        contact = Contact.first
+        expect(call(contact)).to match_array contact.addresses.where(country: usa).to_a
+      end
+    end
+
+    it "memoizes the result" do
+      contacts = Contact.jit_preload.limit(2).to_a
+
+      expect do
+        expect(call(contacts.first))
+        expect(call(contacts.first))
+      end.to make_database_queries(count: 1)
+    end
+
+    context "when reloading the object" do
+      it "clears the memoization" do
+        contacts = Contact.jit_preload.limit(2).to_a
+
+        expect do
+          expect(call(contacts.first))
+        end.to make_database_queries(count: 1)
+        contacts.first.reload
+        expect do
+          expect(call(contacts.first))
+        end.to make_database_queries(count: 1)
+      end
+    end
+
+    it "will issue one query for the group of objects" do
+      contacts = Contact.jit_preload.limit(2).to_a
+
+      usa_addresses = contacts.first.addresses.where(country: usa).to_a
+      expect do
+        expect(call(contacts.first)).to match_array usa_addresses
+      end.to make_database_queries(count: 1)
+
+      usa_addresses = contacts.last.addresses.where(country: usa).to_a
+      expect do
+        expect(call(contacts.last)).to match_array usa_addresses
+      end.to_not make_database_queries
+    end
+
+    it "doesn't load the value into the association" do
+      contacts = Contact.jit_preload.limit(2).to_a
+      call(contacts.first)
+
+      expect(contacts.first.association(:addresses)).to_not be_loaded
+      expect(contacts.last.association(:addresses)).to_not be_loaded
+    end
+
+    context "when the association is already loaded" do
+      it "doesn't change the value of the association" do
+        contacts = Contact.jit_preload.limit(2).to_a
+        contacts.each{|contact| contact.addresses.to_a }
+        contacts.each{|contact| call(contact) }
+
+        expect(contacts.first.association(:addresses)).to be_loaded
+        expect(contacts.last.association(:addresses)).to be_loaded
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes: https://github.com/clio/jit_preloader/issues/20

We add a `preload_scoped_relation` method onto instances of `ActiveRecord::Base` and we can use this to load a subset of an association. 

This method will leave the association untouched as to not create unusual side effects and will memoize the value based on a string passed into so the method can be called on the same object many times without worry. 