### PR TITLE
Add support for rails 6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,24 @@
 PATH
   remote: .
   specs:
-    jit_preloader (0.2.3)
-      activerecord (> 4.2, < 6)
+    jit_preloader (0.2.4)
+      activerecord (> 4.2)
       activesupport
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.4.2)
-      activesupport (= 5.2.4.2)
-    activerecord (5.2.4.2)
-      activemodel (= 5.2.4.2)
-      activesupport (= 5.2.4.2)
-      arel (>= 9.0)
-    activesupport (5.2.4.2)
+    activemodel (6.0.2.2)
+      activesupport (= 6.0.2.2)
+    activerecord (6.0.2.2)
+      activemodel (= 6.0.2.2)
+      activesupport (= 6.0.2.2)
+    activesupport (6.0.2.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    arel (9.0.0)
+      zeitwerk (~> 2.2)
     byebug (9.0.6)
     concurrent-ruby (1.1.6)
     database_cleaner (1.5.3)
@@ -44,10 +43,11 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    sqlite3 (1.3.12)
+    sqlite3 (1.4.2)
     thread_safe (0.3.6)
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
+    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby

--- a/jit_preloader.gemspec
+++ b/jit_preloader.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", "> 4.2", "< 6"
+  spec.add_dependency "activerecord", "> 4.2"
   spec.add_dependency "activesupport"
 
   spec.add_development_dependency "bundler"

--- a/lib/jit_preloader/active_record/associations/preloader/association.rb
+++ b/lib/jit_preloader/active_record/associations/preloader/association.rb
@@ -1,49 +1,26 @@
 module JitPreloader
   module PreloaderAssociation
 
-    # A monkey patch to ActiveRecord. The old method looked like the snippet
-    # below. Our changes here are that we remove records that are already
-    # part of the target, then attach all of the records to a new jit preloader.
-    #
-    # def run(preloader)
-    #   records = load_records do |record|
-    #     owner = owners_by_key[convert_key(record[association_key_name])]
-    #     association = owner.association(reflection.name)
-    #     association.set_inverse_instance(record)
-    #   end
+    # Monkey patching ActiveRecord to use JitPreload
+    # The following methods run, associate_records_to_owner, and build_scope
+    # have been modified from their original functionality.
 
-    #   owners.each do |owner|
-    #     associate_records_to_owner(owner, records[convert_key(owner[owner_key_name])] || [])
-    #   end
-    # end
-
-    def run(preloader)
+    # In <= 5.2, ActiveRecord was passing a parameter to the run method,
+    # in AR 6.0 the function signature no longer has a parameter. This allows this
+    # method to be called the same in both ActiveRecord versions
+    def run(_=nil)
       all_records = []
-      records = load_records do |record|
-        owner = owners_by_key[convert_key(record[association_key_name])]
-        association = owner.association(reflection.name)
-        association.set_inverse_instance(record)
-      end
 
       owners.each do |owner|
-        owned_records = records[convert_key(owner[owner_key_name])] || []
+        owned_records = records_by_owner[owner] || []
         all_records.concat(Array(owned_records)) if owner.jit_preloader || JitPreloader.globally_enabled?
         associate_records_to_owner(owner, owned_records)
       end
 
       JitPreloader::Preloader.attach(all_records) if all_records.any?
+      self
     end
 
-    # Original method:
-    # def associate_records_to_owner(owner, records)
-    #   association = owner.association(reflection.name)
-    #   association.loaded!
-    #   if reflection.collection?
-    #     association.target.concat(records)
-    #   else
-    #     association.target = records.first unless records.empty?
-    #   end
-    # end
     def associate_records_to_owner(owner, records)
       association = owner.association(reflection.name)
       association.loaded!
@@ -59,11 +36,123 @@ module JitPreloader
       end
     end
 
-
     def build_scope
       super.tap do |scope|
         scope.jit_preload! if owners.any?(&:jit_preloader) || JitPreloader.globally_enabled?
       end
+    end
+
+    # The rest of the methods were copied from ActiveRecord 6.0 to make JitPreloader
+    # backwards compatible with Rails versions greater than 4.2 without having to do any
+    # funky version logic in this file.
+
+    def initialize(klass, owners, reflection, preload_scope)
+      @klass         = klass
+      @owners        = owners
+      @reflection    = reflection
+      @preload_scope = preload_scope
+      @model         = owners.first && owners.first.class
+    end
+
+    def records_by_owner
+      load_records unless defined?(@records_by_owner)
+
+      @records_by_owner
+    end
+
+    def preloaded_records
+      load_records unless defined?(@preloaded_records)
+
+      @preloaded_records
+    end
+
+    private
+
+    attr_reader :owners, :reflection, :preload_scope, :model, :klass
+
+    def load_records
+      # owners can be duplicated when a relation has a collection association join
+      # #compare_by_identity makes such owners different hash keys
+      @records_by_owner = {}.compare_by_identity
+      raw_records = owner_keys.empty? ? [] : records_for(owner_keys)
+
+      @preloaded_records = raw_records.select do |record|
+        assignments = false
+
+        owners_by_key[convert_key(record[association_key_name])].each do |owner|
+          entries = (@records_by_owner[owner] ||= [])
+
+          if reflection.collection? || entries.empty?
+            entries << record
+            assignments = true
+          end
+        end
+
+        assignments
+      end
+    end
+
+    # The name of the key on the associated records
+    def association_key_name
+      reflection.join_primary_key(klass)
+    end
+
+    # The name of the key on the model which declares the association
+    def owner_key_name
+      reflection.join_foreign_key
+    end
+
+    def owner_keys
+      @owner_keys ||= owners_by_key.keys
+    end
+
+    def owners_by_key
+      @owners_by_key ||= owners.each_with_object({}) do |owner, result|
+        key = convert_key(owner[owner_key_name])
+        (result[key] ||= []) << owner if key
+      end
+    end
+
+    def key_conversion_required?
+      unless defined?(@key_conversion_required)
+        @key_conversion_required = (association_key_type != owner_key_type)
+      end
+
+      @key_conversion_required
+    end
+
+    def convert_key(key)
+      if key_conversion_required?
+        key.to_s
+      else
+        key
+      end
+    end
+
+    def association_key_type
+      @klass.type_for_attribute(association_key_name).type
+    end
+
+    def owner_key_type
+      @model.type_for_attribute(owner_key_name).type
+    end
+
+    def records_for(ids)
+      scope.where(association_key_name => ids).load do |record|
+        # Processing only the first owner
+        # because the record is modified but not an owner
+        owner = owners_by_key[convert_key(record[association_key_name])].first
+        association = owner.association(reflection.name)
+        association.set_inverse_instance(record)
+      end
+    end
+
+    def scope
+      @scope ||= build_scope
+    end
+
+    def reflection_scope
+      @reflection_scope ||= reflection.scope ? reflection.scope_for(klass.unscoped) : klass.unscoped
     end
   end
 end


### PR DESCRIPTION
I had been looking at this for a bit, before I came across https://github.com/clio/jit_preloader/issues/23. The code I had written to support ActiveRecord 6.0 looked exactly the same as the code snippet included in that issue. The problem with just using only that code is that it isn't backward compatible with other versions of ActiveRecord because of how the Association class has been changed in each version. 

As I started looking through the old versions of the Association class in ActiveRecord I saw they have moved a lot of logic between existing methods so it looked like it was going to be a pain to try and write the run method to work with any version which is why I copied in the latest functions from ActiveRecord. That way the functionality will be consistent regardless of the AR version when this module is prepended to it. There are other ways to go about this but wanted to present this as one of them. Happy to modify based on suggestions and ideas, or you can just reject this PR if it isn't the approach you want to take. 