### PR TITLE
Support overriding the table alias name

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jit_preloader (0.2.3)
+    jit_preloader (0.2.5)
       activerecord (> 4.2, < 6)
       activesupport
 
@@ -63,4 +63,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   2.0.1
+   2.1.4

--- a/lib/jit_preloader/active_record/base.rb
+++ b/lib/jit_preloader/active_record/base.rb
@@ -77,9 +77,10 @@ module JitPreloadExtension
             association_scope = association_scope.instance_exec(&reflection.scope).reorder(nil) if reflection.scope
 
             # If the query uses an alias for the association, use that instead of the table name
-            table_alias_name ||= association_scope.references_values.first || aggregate_association.table_name
+            table_reference = table_alias_name
+            table_reference ||= association_scope.references_values.first || aggregate_association.table_name
 
-            conditions[table_alias_name] = { aggregate_association.foreign_key => primary_ids }
+            conditions[table_reference] = { aggregate_association.foreign_key => primary_ids }
 
             # If the association is a STI child model, specify its type in the condition so that it
             # doesn't include results from other child models
@@ -87,13 +88,13 @@ module JitPreloadExtension
             has_type_column = aggregate_association.klass.column_names.include?(aggregate_association.klass.inheritance_column)
             is_child_sti_model = !parent_is_base_class && has_type_column
             if is_child_sti_model
-              conditions[table_alias_name].merge!({ aggregate_association.klass.inheritance_column => aggregate_association.klass.sti_name })
+              conditions[table_reference].merge!({ aggregate_association.klass.inheritance_column => aggregate_association.klass.sti_name })
             end
 
             if reflection.type.present?
               conditions[reflection.type] = self.class.name
             end
-            group_by = "#{table_alias_name}.#{aggregate_association.foreign_key}"
+            group_by = "#{table_reference}.#{aggregate_association.foreign_key}"
 
             preloaded_data = Hash[association_scope
               .where(conditions)

--- a/lib/jit_preloader/active_record/base.rb
+++ b/lib/jit_preloader/active_record/base.rb
@@ -55,7 +55,7 @@ module JitPreloadExtension
     class << base
       delegate :jit_preload, to: :all
 
-      def has_many_aggregate(assoc, name, aggregate, field, default: 0)
+      def has_many_aggregate(assoc, name, aggregate, field, table_alias_name: nil, default: 0)
         method_name = "#{assoc}_#{name}"
 
         define_method(method_name) do |conditions={}|
@@ -77,10 +77,9 @@ module JitPreloadExtension
             association_scope = association_scope.instance_exec(&reflection.scope).reorder(nil) if reflection.scope
 
             # If the query uses an alias for the association, use that instead of the table name
-            table_alias_name = association_scope.references_values.first
-            table_reference = table_alias_name || aggregate_association.table_name
+            table_alias_name ||= association_scope.references_values.first || aggregate_association.table_name
 
-            conditions[table_reference] = { aggregate_association.foreign_key => primary_ids }
+            conditions[table_alias_name] = { aggregate_association.foreign_key => primary_ids }
 
             # If the association is a STI child model, specify its type in the condition so that it
             # doesn't include results from other child models
@@ -88,13 +87,13 @@ module JitPreloadExtension
             has_type_column = aggregate_association.klass.column_names.include?(aggregate_association.klass.inheritance_column)
             is_child_sti_model = !parent_is_base_class && has_type_column
             if is_child_sti_model
-              conditions[table_reference].merge!({ aggregate_association.klass.inheritance_column => aggregate_association.klass.sti_name })
+              conditions[table_alias_name].merge!({ aggregate_association.klass.inheritance_column => aggregate_association.klass.sti_name })
             end
 
             if reflection.type.present?
               conditions[reflection.type] = self.class.name
             end
-            group_by = "#{table_reference}.#{aggregate_association.foreign_key}"
+            group_by = "#{table_alias_name}.#{aggregate_association.foreign_key}"
 
             preloaded_data = Hash[association_scope
               .where(conditions)

--- a/lib/jit_preloader/version.rb
+++ b/lib/jit_preloader/version.rb
@@ -1,3 +1,3 @@
 module JitPreloader
-  VERSION = "0.2.4"
+  VERSION = "0.2.5"
 end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -12,6 +12,9 @@ class ContactBook < ActiveRecord::Base
   has_many_aggregate :employees, :count, :count, "*"
   has_many_aggregate :company_employees, :count, :count, "*"
   has_many_aggregate :children, :count, :count, "*"
+
+  has_many :companies_with_blank_email_address, -> { joins(:email_address).where(email_addresses: { address: "" }) }, class_name: "Company"
+  has_many_aggregate :companies_with_blank_email_address, :count, :count, "*", table_alias_name: "contacts"
 end
 
 class Contact < ActiveRecord::Base


### PR DESCRIPTION
Continue https://github.com/clio/jit_preloader/pull/18

When the association scope is chained with conditions of other tables, the names of join tables are also added to `references_values`. It becomes impossible to identify the table alias name from the `references_values`.

The PR provides a way to customize the table alias name when the default way cannot figure out the correct value.

## Example queries
For a `ContactBook` has many `companies` and a `Company` has one `email_address`. When it counts the number of `companies` with blank `email_address`, the current implementation is wrong.
```
has_many :companies_with_blank_email_address, -> { joins(:email_address).where(email_addresses: { address: "" }) }, class_name: "Company"
has_many_aggregate :companies_with_blank_email_address, :count, :count, "*", table_alias_name: "contacts"
```
### Invalid query before the fix:
```
ActiveRecord::StatementInvalid:
  SQLite3::SQLException: no such column: email_addresses.contact_book_id: 

SELECT COUNT(*) AS count_all, email_addresses.contact_book_id AS email_addresses_contact_book_id 
FROM "contacts" 
INNER JOIN "email_addresses" ON "email_addresses"."contact_id" = "contacts"."id" 
WHERE "contacts"."type" IN ('Company') 
AND "email_addresses"."address" = ? 
AND "email_addresses"."contact_book_id" = ? 
GROUP BY email_addresses.contact_book_id
```

### Valid query:
```
SELECT COUNT(*) AS count_all, contacts.contact_book_id AS contacts_contact_book_id 
FROM "contacts" 
INNER JOIN "email_addresses" ON "email_addresses"."contact_id" = "contacts"."id" 
WHERE "contacts"."type" IN ('Company') 
AND "email_addresses"."address" = ? 
AND "contacts"."contact_book_id" = ? 
GROUP BY contacts.contact_book_id
```