### PR TITLE
Fix duplicate record assignment

### DIFF
--- a/lib/jit_preloader/active_record/associations/preloader/ar6_association.rb
+++ b/lib/jit_preloader/active_record/associations/preloader/ar6_association.rb
@@ -22,7 +22,7 @@ module JitPreloader
       all_records = []
 
       owners.each do |owner|
-        owned_records = records_by_owner[owner] || []
+        owned_records = records_by_owner[owner]&.uniq || []
         all_records.concat(Array(owned_records)) if owner.jit_preloader || JitPreloader.globally_enabled?
         associate_records_to_owner(owner, owned_records)
       end

--- a/spec/lib/jit_preloader/preloader_spec.rb
+++ b/spec/lib/jit_preloader/preloader_spec.rb
@@ -439,4 +439,23 @@ RSpec.describe JitPreloader::Preloader do
     end
   end
 
+  context "duplicate records" do
+    let!(:contact1) { Contact.new(name: "1 contact, 1 phone number", phone_numbers: [phone_number]) }
+    let!(:contact2) { nil }
+    let!(:contact3) { nil }
+    let!(:contact_owner) { nil }
+
+    let(:phone_number) { PhoneNumber.new(phone: "123") }
+    let!(:email_adresses) do
+      [
+        EmailAddress.create!(address: "woot@woot.com", contact: contact1),
+        EmailAddress.create!(address: "a@a.com", contact: contact1),
+      ]
+    end
+
+    it "does not assign duplicate records" do
+      expect(EmailAddress.jit_preload.to_a.map{|e| e.contact.phone_numbers.length }).to eql([1, 1])
+    end
+  end
+
 end


### PR DESCRIPTION
Hi,

I found the following issue when using `jit_preloader`:

If multiple records in a collection have the same record set for a `belongs_to`, which itself has a `has_many` association, the `has_many` association will end up having duplicate records assigned. When using ARs `preload`, there are no duplicate records.

I could reproduce this behaviour with a spec and was also able to fix it. However, I'm not 100% sure if my fix will add other side effects if there are actually duplicate records via `has_many through:` or similar setups. 

Maybe somebody else with better understanding of the gem itself can simply tell where to apply a fix without side effects.