### PR TITLE
Ensure the specs pass for 5.2 and 6.0

### DIFF
--- a/jit_preloader.gemspec
+++ b/jit_preloader.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", "> 4.2", "< 7"
+  spec.add_dependency "activerecord", "> 5.0", "< 7"
   spec.add_dependency "activesupport"
 
   spec.add_development_dependency "bundler"

--- a/lib/jit_preloader/active_record/associations/preloader/ar5_association.rb
+++ b/lib/jit_preloader/active_record/associations/preloader/ar5_association.rb
@@ -44,7 +44,8 @@ module JitPreloader
         # We don't want to duplicate them, but we also want to preserve
         # the original copy so that we don't blow away in-memory changes.
         new_records = association.target.any? ? records - association.target : records
-        association.target = association.target.concat(new_records)
+        association.target.concat(new_records)
+        association.loaded!
       else
         association.target ||= records.first unless records.empty?
       end

--- a/lib/jit_preloader/active_record/associations/preloader/ar5_association.rb
+++ b/lib/jit_preloader/active_record/associations/preloader/ar5_association.rb
@@ -18,7 +18,7 @@ module JitPreloader
     # end
 
     def run(preloader)
-      super do
+      super.tap do
         if preloaded_records.any?
           JitPreloader::Preloader.attach(preloaded_records) if owners.any?(&:jit_preloader) || JitPreloader.globally_enabled?
         end

--- a/lib/jit_preloader/active_record/associations/preloader/ar5_association.rb
+++ b/lib/jit_preloader/active_record/associations/preloader/ar5_association.rb
@@ -19,7 +19,7 @@ module JitPreloader
 
     def run(preloader)
       super.tap do
-        if preloaded_records.any?
+        if preloaded_records.any? && preloaded_records.none?(&:jit_preloader)
           JitPreloader::Preloader.attach(preloaded_records) if owners.any?(&:jit_preloader) || JitPreloader.globally_enabled?
         end
       end

--- a/lib/jit_preloader/active_record/associations/preloader/ar5_association.rb
+++ b/lib/jit_preloader/active_record/associations/preloader/ar5_association.rb
@@ -18,20 +18,11 @@ module JitPreloader
     # end
 
     def run(preloader)
-      all_records = []
-      records = load_records do |record|
-        owner = owners_by_key[convert_key(record[association_key_name])]
-        association = owner.association(reflection.name)
-        association.set_inverse_instance(record)
+      super do
+        if preloaded_records.any?
+          JitPreloader::Preloader.attach(preloaded_records) if owners.any?(&:jit_preloader) || JitPreloader.globally_enabled?
+        end
       end
-
-      owners.each do |owner|
-        owned_records = records[convert_key(owner[owner_key_name])] || []
-        all_records.concat(Array(owned_records)) if owner.jit_preloader || JitPreloader.globally_enabled?
-        associate_records_to_owner(owner, owned_records)
-      end
-
-      JitPreloader::Preloader.attach(all_records) if all_records.any?
     end
 
     # Original method:
@@ -53,7 +44,7 @@ module JitPreloader
         # We don't want to duplicate them, but we also want to preserve
         # the original copy so that we don't blow away in-memory changes.
         new_records = association.target.any? ? records - association.target : records
-        association.target.concat(new_records)
+        association.target = association.target.concat(new_records)
       else
         association.target ||= records.first unless records.empty?
       end
@@ -69,3 +60,4 @@ module JitPreloader
 end
 
 ActiveRecord::Associations::Preloader::Association.prepend(JitPreloader::PreloaderAssociation)
+ActiveRecord::Associations::Preloader::ThroughAssociation.prepend(JitPreloader::PreloaderAssociation)

--- a/lib/jit_preloader/active_record/associations/preloader/ar6_association.rb
+++ b/lib/jit_preloader/active_record/associations/preloader/ar6_association.rb
@@ -16,7 +16,7 @@ module JitPreloader
     # end
 
     def run
-      super do
+      super.tap do
         if preloaded_records.any?
           JitPreloader::Preloader.attach(preloaded_records) if owners.any?(&:jit_preloader) || JitPreloader.globally_enabled?
         end

--- a/lib/jit_preloader/active_record/associations/preloader/ar6_association.rb
+++ b/lib/jit_preloader/active_record/associations/preloader/ar6_association.rb
@@ -6,57 +6,41 @@ module JitPreloader
     # part of the target, then attach all of the records to a new jit preloader.
     #
     # def run
-    #   if !preload_scope || preload_scope.empty_scope?
-    #     owners.each do |owner|
-    #       associate_records_to_owner(owner, records_by_owner[owner] || [])
-    #     end
-    #   else
-    #     # Custom preload scope is used and
-    #     # the association can not be marked as loaded
-    #     # Loading into a Hash instead
-    #     records_by_owner
-    #   end
+    #   records = records_by_owner
+
+    #   owners.each do |owner|
+    #     associate_records_to_owner(owner, records[owner] || [])
+    #   end if @associate
+
     #   self
     # end
+
     def run
-      all_records = []
-
-      owners.each do |owner|
-        owned_records = records_by_owner[owner] || []
-        all_records.concat(Array(owned_records)) if owner.jit_preloader || JitPreloader.globally_enabled?
-        associate_records_to_owner(owner, owned_records)
+      super do
+        if preloaded_records.any?
+          JitPreloader::Preloader.attach(preloaded_records) if owners.any?(&:jit_preloader) || JitPreloader.globally_enabled?
+        end
       end
-
-      JitPreloader::Preloader.attach(all_records) if all_records.any?
-
-      self
     end
 
     # Original method:
     # def associate_records_to_owner(owner, records)
     #   association = owner.association(reflection.name)
-    #   association.loaded!
     #   if reflection.collection?
-    #     association.target.concat(records)
+    #     association.target = records
     #   else
-    #     association.target = records.first unless records.empty?
+    #     association.target = records.first
     #   end
     # end
     def associate_records_to_owner(owner, records)
       association = owner.association(reflection.name)
-      association.loaded!
-
       if reflection.collection?
-        # It is possible that some of the records are loaded already.
-        # We don't want to duplicate them, but we also want to preserve
-        # the original copy so that we don't blow away in-memory changes.
         new_records = association.target.any? ? records - association.target : records
-        association.target.concat(new_records)
+        association.target = association.target.concat(new_records)
       else
-        association.target ||= records.first unless records.empty?
+        association.target = records.first
       end
     end
-
 
     def build_scope
       super.tap do |scope|
@@ -67,3 +51,4 @@ module JitPreloader
 end
 
 ActiveRecord::Associations::Preloader::Association.prepend(JitPreloader::PreloaderAssociation)
+ActiveRecord::Associations::Preloader::ThroughAssociation.prepend(JitPreloader::PreloaderAssociation)

--- a/lib/jit_preloader/active_record/associations/preloader/ar6_association.rb
+++ b/lib/jit_preloader/active_record/associations/preloader/ar6_association.rb
@@ -36,7 +36,8 @@ module JitPreloader
       association = owner.association(reflection.name)
       if reflection.collection?
         new_records = association.target.any? ? records - association.target : records
-        association.target = association.target.concat(new_records)
+        association.target.concat(new_records)
+        association.loaded!
       else
         association.target = records.first
       end

--- a/lib/jit_preloader/active_record/associations/preloader/ar6_association.rb
+++ b/lib/jit_preloader/active_record/associations/preloader/ar6_association.rb
@@ -17,7 +17,7 @@ module JitPreloader
 
     def run
       super.tap do
-        if preloaded_records.any?
+        if preloaded_records.any? && preloaded_records.none?(&:jit_preloader)
           JitPreloader::Preloader.attach(preloaded_records) if owners.any?(&:jit_preloader) || JitPreloader.globally_enabled?
         end
       end

--- a/lib/jit_preloader/active_record/base.rb
+++ b/lib/jit_preloader/active_record/base.rb
@@ -24,7 +24,7 @@ module JitPreloadExtension
 
       records = jit_preloader&.records || [self]
 
-      preloader_assocaition = ActiveRecord::Associations::Preloader.new.preload(
+      preloader_association = ActiveRecord::Associations::Preloader.new.preload(
         records,
         base_association,
         preload_scope
@@ -33,7 +33,7 @@ module JitPreloadExtension
       records.each do |record|
         record.jit_preload_scoped_relations ||= {}
         association = record.association(base_association)
-        record.jit_preload_scoped_relations[name] = preloader_assocaition.records_by_owner[record]
+        record.jit_preload_scoped_relations[name] = preloader_association.records_by_owner[record]
       end
 
       jit_preload_scoped_relations[name]

--- a/lib/jit_preloader/version.rb
+++ b/lib/jit_preloader/version.rb
@@ -1,3 +1,3 @@
 module JitPreloader
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/lib/jit_preloader/version.rb
+++ b/lib/jit_preloader/version.rb
@@ -1,3 +1,3 @@
 module JitPreloader
-  VERSION = "0.4.0"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
### What is the problem

Turns out that Rails 5.2 and 6.0 are not completely supported. 

Those versions of the gem have both a `ActiveRecord::Association::Preloader::Association` and a `ActiveRecord::Association::Preloader::ThroughAssociation`. Turns out the latter class redefines a method which makes it so the jit_preloader monkey patch doesn't run

https://github.com/rails/rails/tree/5-2-stable/activerecord/lib/active_record/associations/preloader

Further, in 6.0, when we are loading an association with a custom scope, Rails no longer assigns it to the association. Instead it leaves the data as accessible on the `ActiveRecord::Association::Preloader::Association` object. This means we need to update the `scoped_preload_association` method. 

### How does this fix the problem

Since the extended modules that monkey patch ActiveRecord call super, and the ones in Rails don't, we can reuse the same module to patch both classes. 

I've also taken some time to clean up the monkey patches so that they fallback to the original behaviour rather than completely rewriting it where possible. 


### Tests

```
20-11-02T8:26:59 ~/code/jit_preloader  (rails52-support) $ bundle info activerecord | grep "*"
  * activerecord (5.0.7.2)
20-11-02T8:27:05 ~/code/jit_preloader  (rails52-support) $ rspec spec                         

Randomized with seed 51822
......................................

Finished in 0.53978 seconds (files took 0.75494 seconds to load)
38 examples, 0 failures

Randomized with seed 51822
```

```
20-11-02T8:27:38 ~/code/jit_preloader  (rails52-support) $ bundle info activerecord | grep "*"
  * activerecord (5.1.7)
20-11-02T8:27:40 ~/code/jit_preloader  (rails52-support) $ rspec spec                         

Randomized with seed 56051
......................................

Finished in 0.57324 seconds (files took 0.77835 seconds to load)
38 examples, 0 failures

Randomized with seed 56051
```

```
20-11-02T8:28:03 ~/code/jit_preloader  (rails52-support) $ bundle info activerecord | grep "*"
  * activerecord (5.2.4.4)
20-11-02T8:28:05 ~/code/jit_preloader  (rails52-support) $ rspec spec                         

Randomized with seed 12844
......................................

Finished in 0.50588 seconds (files took 0.7826 seconds to load)
38 examples, 0 failures

Randomized with seed 12844
```


```
20-11-02T8:37:09 ~/code/jit_preloader  (rails52-support) $ bundle info activerecord | grep "*"                 
  * activerecord (6.0.3.4)
20-11-02T8:37:13 ~/code/jit_preloader  (rails52-support) $ rspec spec 

Randomized with seed 59410
......................................

Finished in 0.49044 seconds (files took 0.7781 seconds to load)
38 examples, 0 failures

Randomized with seed 59410

```