### PR TITLE
Fix issue with new records.

### DIFF
--- a/lib/jit_preloader/active_record/base.rb
+++ b/lib/jit_preloader/active_record/base.rb
@@ -47,7 +47,7 @@ module JitPreloadExtension
 
       records.each do |record|
         association = record.association(base_association)
-        if association.loaded?
+        if association.loaded? || association.target.any?
           previous_association_values[record] = association.target
           association.reset
         end

--- a/spec/lib/jit_preloader/active_record/base_spec.rb
+++ b/spec/lib/jit_preloader/active_record/base_spec.rb
@@ -44,6 +44,14 @@ RSpec.describe "ActiveRecord::Base Extensions" do
       end.to make_database_queries(count: 1)
     end
 
+    context "with newly created records" do
+      it "ignores new records in scope" do
+        contact = Contact.first
+        new_address = contact.addresses.create!(street: "123 Friendly St.", country: canada)
+        expect(call(contact)).not_to include(new_address)
+      end
+    end
+
     context "when reloading the object" do
       it "clears the memoization" do
         contacts = Contact.jit_preload.limit(2).to_a


### PR DESCRIPTION
When records are newly created, they are appended to `target`.  Target is not loaded, and the association is indicated as not being loaded.  Then, when we go to perform preloading, the newly preloaded records will be appended to the newly created records.

This means that we may not get desired behaviour when we preload onto a object that has recently added objects to the assocation.

This adds a check to the state of target, and, if there are any values, it *also* saves and resets it.  This is done via direct checkign of `target`; I'm not aware of a better way but would love to find one.