### PR TITLE
Bump version to 1.0.1.

### DIFF
--- a/lib/jit_preloader/version.rb
+++ b/lib/jit_preloader/version.rb
@@ -1,3 +1,3 @@
 module JitPreloader
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
Before we can put out a release with https://github.com/clio/jit_preloader/pull/35 in it, we need to bump the version number. (Should have done that as part of https://github.com/clio/jit_preloader/pull/35, probably.)