### PR TITLE
We should not try to preload instance dependent associations as they are not supposed through any kind of preloading

### DIFF
--- a/lib/jit_preloader/active_record/associations/collection_association.rb
+++ b/lib/jit_preloader/active_record/associations/collection_association.rb
@@ -4,7 +4,7 @@ module JitPreloader
     def load_target
       was_loaded = loaded?
 
-      if !loaded? && owner.persisted? && owner.jit_preloader
+      if !loaded? && owner.persisted? && owner.jit_preloader && (reflection.scope.nil? || reflection.scope.arity == 0)
         owner.jit_preloader.jit_preload(reflection.name)
       end
 

--- a/lib/jit_preloader/active_record/associations/singular_association.rb
+++ b/lib/jit_preloader/active_record/associations/singular_association.rb
@@ -4,7 +4,7 @@ module JitPreloader
     def load_target
       was_loaded = loaded?
 
-      if !loaded? && owner.persisted? && owner.jit_preloader
+      if !loaded? && owner.persisted? && owner.jit_preloader && (reflection.scope.nil? || reflection.scope.arity == 0)
         owner.jit_preloader.jit_preload(reflection.name)
       end
 

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -1,5 +1,6 @@
 class ContactBook < ActiveRecord::Base
   has_many :contacts
+  has_many :contacts_with_scope, ->(_contact_book) { desc }, class_name: "Contact", foreign_key: :contact_book_id
   has_many :employees, through: :contacts
 
   has_many :companies
@@ -29,6 +30,8 @@ class Contact < ActiveRecord::Base
   has_many_aggregate :addresses, :max_street_length, :maximum, "LENGTH(street)"
   has_many_aggregate :phone_numbers, :count, :count, "id"
   has_many_aggregate :addresses, :count, :count, "*"
+
+  scope :desc, ->{ order(id: :desc) }
 end
 
 class Company < Contact


### PR DESCRIPTION
Building off https://github.com/clio/jit_preloader/pull/35

We should also prevent loading instance dependent association automatically. 