### PR TITLE
Bump version to 1.0.2.

### DIFF
--- a/lib/jit_preloader/version.rb
+++ b/lib/jit_preloader/version.rb
@@ -1,3 +1,3 @@
 module JitPreloader
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
We want to build a new version of the gem which contains https://github.com/clio/jit_preloader/pull/37, so here's a version bump.