### PR TITLE
`preload_scoped_relation` returns `nil` instead of `[]` for empty associations

### DIFF
--- a/jit_preloader.gemspec
+++ b/jit_preloader.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", "> 5.0", "< 7"
+  spec.add_dependency "activerecord", "> 6.0", "< 6.1"
   spec.add_dependency "activesupport"
 
   spec.add_development_dependency "bundler"

--- a/lib/jit_preloader/active_record/base.rb
+++ b/lib/jit_preloader/active_record/base.rb
@@ -33,7 +33,7 @@ module JitPreloadExtension
       records.each do |record|
         record.jit_preload_scoped_relations ||= {}
         association = record.association(base_association)
-        record.jit_preload_scoped_relations[name] = preloader_association.records_by_owner[record]
+        record.jit_preload_scoped_relations[name] = preloader_association.records_by_owner[record] || []
       end
 
       jit_preload_scoped_relations[name]

--- a/lib/jit_preloader/version.rb
+++ b/lib/jit_preloader/version.rb
@@ -1,3 +1,3 @@
 module JitPreloader
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end

--- a/spec/lib/jit_preloader/active_record/base_spec.rb
+++ b/spec/lib/jit_preloader/active_record/base_spec.rb
@@ -90,5 +90,18 @@ RSpec.describe "ActiveRecord::Base Extensions" do
         expect(contacts.last.association(:addresses)).to be_loaded
       end
     end
+
+    context "when no records exist for the association" do
+      let!(:record) { Parent.create }
+
+      it "returns an empty array" do
+        value = record.preload_scoped_relation(
+          name: "Parent Children",
+          base_association: :parents_child
+        )
+
+        expect(value).to eq([])
+      end
+    end
   end
 end


### PR DESCRIPTION
https://github.com/clio/backend-infrastructure/issues/1687

Changes to ActiveRecord, between 5.17 and 6.0.3.5, has resulted in `ActiveRecord::Associations::Preloader#records_by_owner` returning `nil` instead of `[]` for empty associations.

The changes are shown here under `def records_by_owner` (line# ~29) https://github.com/rails/rails/compare/5aaaa1630ae9a71b3c3ecc4dc46074d678c08d67..c5929d5eb55b749bc124b3ccc2d79323d015701f#diff-97709b319ca07f6cd3f4d6b8a8c443d0cb3e7487696098be377aa9fa78907a35