### PR TITLE
Bump activerecord for rails 6.1

### DIFF
--- a/jit_preloader.gemspec
+++ b/jit_preloader.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", "> 6.0", "< 6.1"
+  spec.add_dependency "activerecord", "> 6.0", "< 7"
   spec.add_dependency "activesupport"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
I'm updating a Rails app to 6.1 that uses this gem. It looks like the gemspec was changed to not support 6.1 due to this issue: https://github.com/clio/jit_preloader/pull/39. However, now that this is merged it seems it could be changed back to support 6.1. I didn't run into any problems in our app running it with 6.1 but there might be other unforeseen issues I didn't run across.