### PR TITLE
In some circumstances singular associations do not reload properly

### DIFF
--- a/Gemfile.5.2
+++ b/Gemfile.5.2
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem "activerecord", "~>5.2"
+
+# Specify your gem's dependencies in jit_preloader.gemspec
+gemspec

--- a/Gemfile.5.2.lock
+++ b/Gemfile.5.2.lock
@@ -1,0 +1,72 @@
+PATH
+  remote: .
+  specs:
+    jit_preloader (1.0.3)
+      activerecord (>= 5.2, < 7)
+      activesupport
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (5.2.6)
+      activesupport (= 5.2.6)
+    activerecord (5.2.6)
+      activemodel (= 5.2.6)
+      activesupport (= 5.2.6)
+      arel (>= 9.0)
+    activesupport (5.2.6)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    arel (9.0.0)
+    byebug (11.1.3)
+    concurrent-ruby (1.1.9)
+    database_cleaner (2.0.1)
+      database_cleaner-active_record (~> 2.0.0)
+    database_cleaner-active_record (2.0.1)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
+    db-query-matchers (0.10.0)
+      activesupport (>= 4.0, < 7)
+      rspec (~> 3.0)
+    diff-lcs (1.4.4)
+    i18n (1.8.10)
+      concurrent-ruby (~> 1.0)
+    minitest (5.14.4)
+    rake (13.0.6)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+    sqlite3 (1.4.2)
+    thread_safe (0.3.6)
+    tzinfo (1.2.9)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  x86_64-darwin-19
+
+DEPENDENCIES
+  activerecord (~> 5.2)
+  bundler
+  byebug
+  database_cleaner
+  db-query-matchers
+  jit_preloader!
+  rake (~> 13.0)
+  rspec
+  sqlite3
+
+BUNDLED WITH
+   2.2.12

--- a/Gemfile.6.0
+++ b/Gemfile.6.0
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem "activerecord", "~>6.0.0"
+
+# Specify your gem's dependencies in jit_preloader.gemspec
+gemspec

--- a/Gemfile.6.0.lock
+++ b/Gemfile.6.0.lock
@@ -1,0 +1,72 @@
+PATH
+  remote: .
+  specs:
+    jit_preloader (1.0.3)
+      activerecord (>= 5.2, < 7)
+      activesupport
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (6.0.4.1)
+      activesupport (= 6.0.4.1)
+    activerecord (6.0.4.1)
+      activemodel (= 6.0.4.1)
+      activesupport (= 6.0.4.1)
+    activesupport (6.0.4.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
+    byebug (11.1.3)
+    concurrent-ruby (1.1.9)
+    database_cleaner (2.0.1)
+      database_cleaner-active_record (~> 2.0.0)
+    database_cleaner-active_record (2.0.1)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
+    db-query-matchers (0.10.0)
+      activesupport (>= 4.0, < 7)
+      rspec (~> 3.0)
+    diff-lcs (1.4.4)
+    i18n (1.8.10)
+      concurrent-ruby (~> 1.0)
+    minitest (5.14.4)
+    rake (13.0.6)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+    sqlite3 (1.4.2)
+    thread_safe (0.3.6)
+    tzinfo (1.2.9)
+      thread_safe (~> 0.1)
+    zeitwerk (2.4.2)
+
+PLATFORMS
+  x86_64-darwin-19
+
+DEPENDENCIES
+  activerecord (~> 6.0.0)
+  bundler
+  byebug
+  database_cleaner
+  db-query-matchers
+  jit_preloader!
+  rake (~> 13.0)
+  rspec
+  sqlite3
+
+BUNDLED WITH
+   2.2.12

--- a/Gemfile.6.1
+++ b/Gemfile.6.1
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem "activerecord", "~>6.1.0"
+
+# Specify your gem's dependencies in jit_preloader.gemspec
+gemspec

--- a/Gemfile.6.1.lock
+++ b/Gemfile.6.1.lock
@@ -1,0 +1,71 @@
+PATH
+  remote: .
+  specs:
+    jit_preloader (1.0.3)
+      activerecord (>= 5.2, < 7)
+      activesupport
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (6.1.4.1)
+      activesupport (= 6.1.4.1)
+    activerecord (6.1.4.1)
+      activemodel (= 6.1.4.1)
+      activesupport (= 6.1.4.1)
+    activesupport (6.1.4.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    byebug (11.1.3)
+    concurrent-ruby (1.1.9)
+    database_cleaner (2.0.1)
+      database_cleaner-active_record (~> 2.0.0)
+    database_cleaner-active_record (2.0.1)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
+    db-query-matchers (0.10.0)
+      activesupport (>= 4.0, < 7)
+      rspec (~> 3.0)
+    diff-lcs (1.4.4)
+    i18n (1.8.10)
+      concurrent-ruby (~> 1.0)
+    minitest (5.14.4)
+    rake (13.0.6)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+    sqlite3 (1.4.2)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    zeitwerk (2.4.2)
+
+PLATFORMS
+  x86_64-darwin-19
+
+DEPENDENCIES
+  activerecord (~> 6.1.0)
+  bundler
+  byebug
+  database_cleaner
+  db-query-matchers
+  jit_preloader!
+  rake (~> 13.0)
+  rspec
+  sqlite3
+
+BUNDLED WITH
+   2.2.12

--- a/jit_preloader.gemspec
+++ b/jit_preloader.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", "> 6.0", "< 6.1"
+  spec.add_dependency "activerecord", ">= 5.2", "< 7"
   spec.add_dependency "activesupport"
 
   spec.add_development_dependency "bundler"

--- a/lib/jit_preloader/active_record/associations/preloader/ar5_association.rb
+++ b/lib/jit_preloader/active_record/associations/preloader/ar5_association.rb
@@ -49,7 +49,7 @@ module JitPreloader
         association.target.concat(new_records)
         association.loaded!
       else
-        association.target ||= records.first unless records.empty?
+        association.target = records.first unless records.empty?
       end
     end
 

--- a/spec/lib/jit_preloader/active_record/base_spec.rb
+++ b/spec/lib/jit_preloader/active_record/base_spec.rb
@@ -74,6 +74,9 @@ RSpec.describe "ActiveRecord::Base Extensions" do
 
     it "doesn't load the value into the association" do
       contacts = Contact.jit_preload.limit(2).to_a
+      expect(contacts.first.association(:addresses)).to_not be_loaded
+      expect(contacts.last.association(:addresses)).to_not be_loaded
+
       call(contacts.first)
 
       expect(contacts.first.association(:addresses)).to_not be_loaded


### PR DESCRIPTION
Looks like when we some records and preload a singular association
e.g.
```ruby
      companies = Company.where(id: [company1.id, company2.id]).jit_preload.all.to_a
      expect(companies.map(&:contact_book)).to match_array [contact_book1, contact_book1]
```

and then change the foreign_key to that it is completely different than any record in the current set
```ruby
      company = companies.each {|c| c.contact_book_id = contact_book2.id }
```

The association isn't properly cleared and you can end up with a situation where the association and the foreign_key do not align
eg.
```
comapny.contact_book_id != company.contact_book.id
```

This seems to be because there is an `||=` being used to set the `target` when we are associating the records to the owner. This appears fixed in Rails 6. The original method (as commented above the monkey patched one) looks like it doesn't use `||=`, so I've updated the patch to not use it as well which fixes the issue. 

--- 

Additionally, I have relaxed the constraints in the Gemfile so that Rails 5.2 is still supported, and I have noticed that specs are failing for Rails 6.0 and 6.1 due to the Rails 6 version of `preload_scoped_relation` not restoring the previous association values. I've mirrored how it is done in the non-6.0 branch. 

I've added specific gemfiles so that it is easier to run the tests in different rails versions with
```
BUNDLE_GEMFILE=Gemfile.XX bundle install
BUNDLE_GEMFILE=Gemfile.XX bundle exec rspec spec
```

