### PR TITLE
#43 allow support for rails 6.1.4.1

### DIFF
--- a/Gemfile.6.1
+++ b/Gemfile.6.1
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "activerecord", "~>6.1.0"
+gem "activerecord", "~>6.1"
 
 # Specify your gem's dependencies in jit_preloader.gemspec
 gemspec

--- a/Gemfile.6.1.4.1
+++ b/Gemfile.6.1.4.1
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gem "activerecord", "~>6.1"
-
-# Specify your gem's dependencies in jit_preloader.gemspec
-gemspec

--- a/Gemfile.6.1.4.1
+++ b/Gemfile.6.1.4.1
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem "activerecord", "~>6.1"
+
+# Specify your gem's dependencies in jit_preloader.gemspec
+gemspec

--- a/Gemfile.6.1.lock
+++ b/Gemfile.6.1.lock
@@ -54,10 +54,11 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  ruby
   x86_64-darwin-19
 
 DEPENDENCIES
-  activerecord (~> 6.1.0)
+  activerecord (~> 6.1)
   bundler
   byebug
   database_cleaner

--- a/lib/jit_preloader/version.rb
+++ b/lib/jit_preloader/version.rb
@@ -1,3 +1,3 @@
 module JitPreloader
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
 end


### PR DESCRIPTION
Problem?

We want to attempt to get manage to run on rails 6.1.4.1; however, the jit_preloader only supports 6.1.0. 

This ticket resolves this by specifying creating a gemfile that supports 6.1.4.1 