### PR TITLE
Enable manual workflow for testing: to be removed later

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -1,6 +1,7 @@
 name: Ruby Gem
 
 on:
+  workflow_dispatch:
   release:
     types: [ published ]
 


### PR DESCRIPTION
We already have a release, and so can't test out this action without making a new one. Adding a manual workflow option so we can test it out, then remove it once it's no longer needed.