### PR TITLE
Rails 7 support

### DIFF
--- a/jit_preloader.gemspec
+++ b/jit_preloader.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 5.2", "< 7"
+  spec.add_dependency "activerecord", ">= 5.2", "< 8"
   spec.add_dependency "activesupport"
 
   spec.add_development_dependency "bundler"

--- a/lib/jit_preloader/active_record/base.rb
+++ b/lib/jit_preloader/active_record/base.rb
@@ -33,11 +33,11 @@ module JitPreloadExtension
         end
       end
 
-      preloader_association = ActiveRecord::Associations::Preloader.new.preload(
-        records,
-        base_association,
-        preload_scope
-      ).first
+      preloader_association = ActiveRecord::Associations::Preloader.new(
+        records: records,
+        associations: base_association,
+        scope: preload_scope
+      ).call.first
 
       records.each do |record|
         record.jit_preload_scoped_relations ||= {}

--- a/lib/jit_preloader/preloader.rb
+++ b/lib/jit_preloader/preloader.rb
@@ -4,7 +4,7 @@ module JitPreloader
     attr_accessor :records
 
     def self.attach(records)
-      new(records: records.dup).tap do |loader|
+      new(records: records.dup, associations: nil).tap do |loader|
         records.each do |record|
           record.jit_preloader = loader
         end

--- a/lib/jit_preloader/preloader.rb
+++ b/lib/jit_preloader/preloader.rb
@@ -4,19 +4,18 @@ module JitPreloader
     attr_accessor :records
 
     def self.attach(records)
-      new.tap do |loader|
-        loader.records = records.dup
+      new(records: records.dup).tap do |loader|
         records.each do |record|
           record.jit_preloader = loader
         end
       end
     end
 
-    def jit_preload(association)
+    def jit_preload(associations)
       # It is possible that the records array has multiple different classes (think single table inheritance).
       # Thus, it is possible that some of the records don't have an association.
-      records_with_association = records.reject{|r| r.class.reflect_on_association(association).nil? }
-      preload records_with_association, association
+      records_with_association = records.reject{|r| r.class.reflect_on_association(associations).nil? }
+      self.class.new(records: records_with_association, associations: associations).call
     end
 
     # We do not want the jit_preloader to be dumpable


### PR DESCRIPTION
Fixes:

```
DEPRECATION WARNING: Calling `Preloader#initialize` without arguments is deprecated and will be removed in Rails 7.0. 
DEPRECATION WARNING: `preload` is deprecated and will be removed in Rails 7.0. Call `Preloader.new(kwargs).call` instead.
```