### PR TITLE
Support joins in an association's scope for preloading

### DIFF
--- a/spec/lib/jit_preloader/preloader_spec.rb
+++ b/spec/lib/jit_preloader/preloader_spec.rb
@@ -218,6 +218,19 @@ RSpec.describe JitPreloader::Preloader do
     end
   end
 
+  context "when accessing an association with an additional joins in the scope" do
+    let!(:contact1) { Contact.create(name: "Test") }
+    let!(:contact2) { Contact.create(name: "Contact2") }
+    let!(:address1) { Address.create(street: "123 Fake st", country: canada, contact: contact1) }
+    let!(:address2) { Address.create(street: "123 Fake st 2", country: usa, contact: contact2) }
+
+    it "can handle queries" do
+      countries = Country.all.jit_preload.to_a
+      expect(countries.first.addresses_for_test_count).to eq 1
+    end
+  end
+
+
   context "when preloading an aggregate on a polymorphic has_many through relationship" do
     let(:contact_owner_addresses_counts) { [3] }
 

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -73,9 +73,11 @@ class Country < ActiveRecord::Base
   has_many :addresses
   has_many :contacts, through: :addresses
   has_many :contact_owners, through: :contacts, source_type: 'ContactOwner'
+  has_many :addresses_for_test, -> { joins(:contact).where(contact: { name: 'Test' }) }, class_name: 'Address', foreign_key: 'country_id'
 
   has_many_aggregate :contacts, :count, :count, "*"
   has_many_aggregate :contact_owners, :count, :count, "*"
+  has_many_aggregate :addresses_for_test, :count, :count, "*"
 end
 
 class ContactOwner < ActiveRecord::Base


### PR DESCRIPTION
Went to go update jit_preloader (was on a version that didn't have the STI changes yet, and it broke several has_many_aggregates. The reason was that the table_reference was incorrect because these has_many_aggregates had a join in their scope along with a where and the current code didn't take that into account. Don't know if this is the best way to go about it but it does solve the problem I was facing. 