### PR TITLE
bump version and active record dependency

### DIFF
--- a/jit_preloader.gemspec
+++ b/jit_preloader.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 5.2", "< 8"
+  spec.add_dependency "activerecord", ">= 7", "< 8"
   spec.add_dependency "activesupport"
 
   spec.add_development_dependency "bundler"

--- a/lib/jit_preloader/version.rb
+++ b/lib/jit_preloader/version.rb
@@ -1,3 +1,3 @@
 module JitPreloader
-  VERSION = "1.0.4"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
This [pr](https://github.com/clio/jit_preloader/pull/50) introduces some breaking changes with how preloader handles arguments in rails 6 vs 7. To communicate this new jit_preloader as a breaking version change we'll bump a major version on the gem. We also want to update the gem spec to tell bundler that the new version requires activerecord 7.

