### PR TITLE
Remove order in has_many_aggregate queries

### DIFF
--- a/lib/jit_preloader/active_record/base.rb
+++ b/lib/jit_preloader/active_record/base.rb
@@ -109,7 +109,7 @@ module JitPreloadExtension
             end
 
             association_scope = klass.all.merge(association(assoc).scope).unscope(where: aggregate_association.foreign_key)
-            association_scope = association_scope.instance_exec(&reflection.scope).reorder(nil) if reflection.scope
+            association_scope = association_scope.instance_exec(&reflection.scope) if reflection.scope
 
             # If the query uses an alias for the association, use that instead of the table name
             table_reference = table_alias_name
@@ -134,6 +134,7 @@ module JitPreloadExtension
             preloaded_data = Hash[association_scope
               .where(conditions)
               .group(group_by)
+              .reorder(nil)
               .send(aggregate, field)
             ]
 


### PR DESCRIPTION
This fixes `has_many_aggregate` on relations with default scope. In the following example one of the associations has a default scope.

```ruby
class Collection < ApplicationRecord
  has_many :collection_products
  has_many :products, through: :collection_products

  has_many_aggregate :products, :count, :count, "*"
end

class CollectionProduct < ApplicationRecord
  default_scope { order sort_order: :asc }

  belongs_to :collection
  belongs_to :product
end
```

The `products_count` method generates the query and error below:

```sql
SELECT COUNT(*) AS "count_all", "collection_products"."collection_id" 
  AS "collection_products_collection_id" FROM "products" 
  INNER JOIN "collection_products" ON "products"."id" = "collection_products"."product_id" 
  WHERE "collection_products"."collection_id" IN (1, 2, 3) 
  GROUP BY "collection_products"."collection_id" 
  ORDER BY "collection_products"."sort_order" ASC
```
```
ERROR:  column "collection_products.sort_order" must appear in the GROUP BY clause 
or be used in an aggregate function (PG::GroupingError)
```