### PR TITLE
Fix an issue with Rails7 monkey patch

### DIFF
--- a/lib/jit_preloader.rb
+++ b/lib/jit_preloader.rb
@@ -8,7 +8,9 @@ require 'jit_preloader/active_record/base'
 require 'jit_preloader/active_record/relation'
 require 'jit_preloader/active_record/associations/collection_association'
 require 'jit_preloader/active_record/associations/singular_association'
-if Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new("6.0.0")
+if Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new("7.0.0")
+  require 'jit_preloader/active_record/associations/preloader/ar7_association'
+elsif Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new("6.0.0")
   require 'jit_preloader/active_record/associations/preloader/ar6_association'
 elsif Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new("5.2.2")
   require 'jit_preloader/active_record/associations/preloader/ar5_association'

--- a/lib/jit_preloader/active_record/associations/preloader/ar7_association.rb
+++ b/lib/jit_preloader/active_record/associations/preloader/ar7_association.rb
@@ -1,0 +1,63 @@
+module JitPreloader
+  module PreloaderAssociation
+
+    # A monkey patch to ActiveRecord. The old method looked like the snippet
+    # below. Our changes here are that we remove records that are already
+    # part of the target, then attach all of the records to a new jit preloader.
+    #
+    # def run
+    #   records = records_by_owner
+
+    #   owners.each do |owner|
+    #     associate_records_to_owner(owner, records[owner] || [])
+    #   end if @associate
+
+    #   self
+    # end
+
+    def run
+      return unless (reflection.scope.nil? || reflection.scope.arity == 0) && klass.ancestors.include?(ActiveRecord::Base)
+
+      super.tap do
+        if preloaded_records.any? && preloaded_records.none?(&:jit_preloader)
+          JitPreloader::Preloader.attach(preloaded_records) if owners.any?(&:jit_preloader) || JitPreloader.globally_enabled?
+        end
+      end
+    end
+
+    # Original method:
+    # def associate_records_to_owner(owner, records)
+    #   return if loaded?(owner)
+    #
+    #   association = owner.association(reflection.name)
+    #
+    #   if reflection.collection?
+    #     association.target = records
+    #   else
+    #     association.target = records.first
+    #   end
+    # end
+    def associate_records_to_owner(owner, records)
+      return if loaded?(owner)
+
+      association = owner.association(reflection.name)
+
+      if reflection.collection?
+        new_records = association.target.any? ? records - association.target : records
+        association.target.concat(new_records)
+        association.loaded!
+      else
+        association.target = records.first
+      end
+    end
+
+    def build_scope
+      super.tap do |scope|
+        scope.jit_preload! if owners.any?(&:jit_preloader) || JitPreloader.globally_enabled?
+      end
+    end
+  end
+end
+
+ActiveRecord::Associations::Preloader::Association.prepend(JitPreloader::PreloaderAssociation)
+ActiveRecord::Associations::Preloader::ThroughAssociation.prepend(JitPreloader::PreloaderAssociation)


### PR DESCRIPTION
## Description

The monkey patch for `associate_records_to_owner` has changed between Rails 6 and Rails 7. 

In Rails 6.0 the [method](https://github.com/rails/rails/blob/6-0-stable/activerecord/lib/active_record/associations/preloader/association.rb#L73-L79) is missing a guard clause.

This is present in the [same method](https://github.com/rails/rails/blob/7-0-stable/activerecord/lib/active_record/associations/preloader/association.rb#L229-L239) in Rails 7. 


This PR adds the rails 7 equivalent monkey patch in the same style that was used for the rails 5 & 6 patches. 
