### PR TITLE
Update version to 2.0.1.

### DIFF
--- a/lib/jit_preloader/version.rb
+++ b/lib/jit_preloader/version.rb
@@ -1,3 +1,3 @@
 module JitPreloader
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end


### PR DESCRIPTION
This will push a new version of the gem that includes Kyle d'Oliveira's [recent Rails 7 fixes.](https://github.com/clio/jit_preloader/pull/57#issuecomment-1795714899)