### PR TITLE
Error reloading an association after it is written

### DIFF
--- a/lib/jit_preloader/preloader.rb
+++ b/lib/jit_preloader/preloader.rb
@@ -15,7 +15,11 @@ module JitPreloader
       # It is possible that the records array has multiple different classes (think single table inheritance).
       # Thus, it is possible that some of the records don't have an association.
       records_with_association = records.reject{|r| r.class.reflect_on_association(associations).nil? }
-      self.class.new(records: records_with_association, associations: associations).call
+
+      # Some of the records may already have the association loaded and we should not load them again
+      records_requiring_loading = records_with_association.select{|r| !r.association(associations).loaded? }
+
+      self.class.new(records: records_requiring_loading, associations: associations).call
     end
 
     # We do not want the jit_preloader to be dumpable


### PR DESCRIPTION
## Description 

We should only apply the jit_preloader preload when all records in the association haven't been preloaded. 
Otherwise we can get into some weird scenarios where the association fails to find any records

Using `loaded?` in the `load_target` method is only checks that the association we are looking at is not loaded, but other associations in the collection could be not loaded and that can cause errors. 

To illustrate this, you can do something like (from the specs)

```
       companies = Company.where(id: [company1.id, company2.id]).preload(:contact_book).jit_preload.all.to_a
       companies.each {|c| c.contact_book_id = contact_book2.id }
       companies.map {|c| c.contact_book }
```

On line 1, the `contact_book` association is `preloaded` as expected.  
On line 2 the attribute for the contact book changes so those associations are marked as stale. 

On line 3, we try to go re-fetch the contact_book. It will hit the first company, and try to preload `contact_book` and then it will try to do it on the second record as well. Unfortunately, the end result is that the map will return `[nil, nil]` which is very unexpected. 

We can get around it and keep with the spirit of the `load_target` check but ensuring that none of the records have had their association loaded yet. 