### PR TITLE
Remove the association loader if the polymorphic class is not a child of ActiveRecord::Base

### DIFF
--- a/lib/jit_preloader.rb
+++ b/lib/jit_preloader.rb
@@ -10,6 +10,7 @@ require 'jit_preloader/active_record/associations/collection_association'
 require 'jit_preloader/active_record/associations/singular_association'
 if Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new("7.0.0")
   require 'jit_preloader/active_record/associations/preloader/ar7_association'
+  require 'jit_preloader/active_record/associations/preloader/ar7_branch'
 elsif Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new("6.0.0")
   require 'jit_preloader/active_record/associations/preloader/ar6_association'
 elsif Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new("5.2.2")

--- a/lib/jit_preloader/active_record/associations/preloader/ar7_branch.rb
+++ b/lib/jit_preloader/active_record/associations/preloader/ar7_branch.rb
@@ -1,0 +1,22 @@
+module JitPreloader
+  module PreloaderBranch
+    """
+    ActiveRecord version >= 7.x.x introduced an improvement for preloading associations in batches:
+    https://github.com/rails/rails/blob/main/activerecord/lib/active_record/associations/preloader.rb#L121
+
+    Our existing monkey-patches will ignore associations whose classes are not descendants of
+    ActiveRecord::Base (example: https://github.com/clio/jit_preloader/blob/master/lib/jit_preloader/active_record/associations/preloader/ar6_association.rb#L19).
+    But this change breaks that behaviour because now Batch is calling `klass.base_class` (a method defined by ActiveRecord::Base)
+    before we have a chance to filter out the non-AR classes.
+    This patch for AR 7.x makes the Branch class ignore any association loaders that aren't for ActiveRecord::Base subclasses.
+    """
+
+    def loaders
+      @loaders = super.find_all do |loader|
+        loader.klass < ::ActiveRecord::Base
+      end
+    end
+  end
+end
+
+ActiveRecord::Associations::Preloader::Branch.prepend(JitPreloader::PreloaderBranch)


### PR DESCRIPTION
ActiveRecord Version >= 7.0.0 is introducing a [`active_record/associations/preloader/batch`](https://github.com/rails/rails/blob/v7.0.0.alpha1/activerecord/lib/active_record/associations/preloader.rb#L49C40-L49C82) file to process all associations in batch.
This introduces an [early check](https://github.com/rails/rails/blob/v7.0.0/activerecord/lib/active_record/associations/preloader/batch.rb#L17) of whether a association klass is a valid ActiveRecord::Base class.
Previously, we [override](https://github.com/clio/jit_preloader/blob/9f5abb11a40972968b4a9829d83cdea358c92fd0/lib/jit_preloader/active_record/associations/preloader/ar7_association.rb#L19) the `Preloader::Association` and `Preloader::ThroughAssociation` `run` method to direct return when a association.klass is not a valid ActiveRecord class is not valid anymore. We have to move the check to an earlier process in batch file.

The PR add an prepend to override `batch.loaders` method and `@loaders` value by removing the invalid association which does not contain a valid ActiveRecord klass.