### PR TITLE
Update has_many_aggregate preload function to slice query into multiple ones base on dive limit

### DIFF
--- a/lib/jit_preloader.rb
+++ b/lib/jit_preloader.rb
@@ -25,6 +25,16 @@ module JitPreloader
     @enabled = value
   end
 
+  def self.max_ids_per_query=(max_ids)
+    if max_ids && max_ids >= 1
+      @max_ids_per_query = max_ids
+    end
+  end
+
+  def self.max_ids_per_query
+    @max_ids_per_query
+  end
+
   def self.globally_enabled?
     if @enabled && @enabled.respond_to?(:call)
       @enabled.call

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -10,6 +10,7 @@ class ContactBook < ActiveRecord::Base
   has_many :children, through: :parents
 
   has_many_aggregate :companies, :count, :count, "*"
+  has_many_aggregate :companies, :count_with_max_ids_set, :count, "*", max_ids_per_query: 2
   has_many_aggregate :employees, :count, :count, "*"
   has_many_aggregate :company_employees, :count, :count, "*"
   has_many_aggregate :children, :count, :count, "*"


### PR DESCRIPTION
From the [discourse post](https://discourse.clio.systems/t/side-affect-danger-for-changing-activerecord-model-association-utilization-of-jit-preloader/3406/2), we know that `has_many_aggregate` preload function may create inefficient query if the preload records are over the Mysql dive limit.

I am adding the ability to set a dive limit and slice the query base.
Not setting the dive limit will fall back to generate a single preload query.