### PR TITLE
Refactor gem to be compatible with multiple ActiveRecord versions; Adding ci github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        gemfile:
+          - Gemfile
+          - Gemfile.5.2
+          - Gemfile.6.0
+          - Gemfile.6.1
+    env:
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run:
+          bundle exec rspec

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
+.idea/*
 
 # Used by dotenv library to load environment variables.
 # .env

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
+gem "activerecord", ">=7"
 # Specify your gem's dependencies in jit_preloader.gemspec
 gemspec

--- a/jit_preloader.gemspec
+++ b/jit_preloader.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 7", "< 8"
+  spec.add_dependency "activerecord", "< 8"
   spec.add_dependency "activesupport"
 
   spec.add_development_dependency "bundler"

--- a/lib/jit_preloader/active_record/base.rb
+++ b/lib/jit_preloader/active_record/base.rb
@@ -18,7 +18,7 @@ module JitPreloadExtension
     end
   end
 
-  if Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new("6.0.0")
+  if Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new("7.0.0")
     def preload_scoped_relation(name:, base_association:, preload_scope: nil)
       return jit_preload_scoped_relations[name] if jit_preload_scoped_relations&.key?(name)
 

--- a/lib/jit_preloader/version.rb
+++ b/lib/jit_preloader/version.rb
@@ -1,3 +1,3 @@
 module JitPreloader
-  VERSION = "2.0.2"
+  VERSION = "2.1.0"
 end


### PR DESCRIPTION
The PR contains multiple changes,
1. Adding `ci.yml` for running spec against different ActiveRecord versions.
2. Refactor gems to make sure _it is_ compatible with different ActiveRecord (5.x.x, 6.x.x and 7.x.x)
3. Refactor README.md with information from [this previous PR](https://github.com/clio/jit_preloader/pull/63)
4. Bump the version for preparation of new release

