### PR TITLE
Refactor the deprecate action; Use the latest checkout action

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -12,11 +12,11 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby 2.7
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.x
+        ruby-version: 2.7
 
     - name: Publish to RubyGems
       env:


### PR DESCRIPTION
* The action `actions/setup-ruby@v1` is deprecated, switch to use `ruby/setup-ruby@v1`.
* Update actions/checkout to use the latest version(v4)

[Reference](https://github.com/clio/jit_preloader/actions/runs/8838079113/job/24268381446)