### PR TITLE
Refactor ci.yml to abide with peng's rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Refactor according to this [issue](https://github.com/clio/jit_preloader/issues/65) ticket and [confluence page](https://themis.atlassian.net/wiki/spaces/INF/pages/2859499526/Github+Actions+-+Workflow+Best+Practices).

---------------------------------------------------
After [talking with peng](https://clio.slack.com/archives/C05M2QE8A2K/p1716571108599179?thread_ts=1716308088.547639&cid=C05M2QE8A2K), we decided to keep public gem on the github public runner and set a hard coded timeout. 