### PR TITLE
Add homepage for gem

### DIFF
--- a/jit_preloader.gemspec
+++ b/jit_preloader.gemspec
@@ -10,7 +10,10 @@ Gem::Specification.new do |spec|
   spec.email         = ["kyle.doliveira@clio.com"]
   spec.summary       = %q{Tool to understand N+1 queries and to remove them}
   spec.description   = %q{The JitPreloader has the ability to send notifications when N+1 queries occur to help guage how problematic they are for your code base and a way to remove all of the commons explicitly or automatically}
-  spec.homepage      = ""
+  spec.homepage      = "https://github.com/clio/jit_preloader"
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = spec.homepage
+
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")


### PR DESCRIPTION
to add the link from https://rubygems.org/gems/jit_preloader to https://github.com/clio/jit_preloader