### PR TITLE
Make sure we correctly find the association within preload_scoped_relation method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ Gemfile.lock
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+.ruby-version

--- a/lib/jit_preloader/active_record/base.rb
+++ b/lib/jit_preloader/active_record/base.rb
@@ -22,6 +22,7 @@ module JitPreloadExtension
     def preload_scoped_relation(name:, base_association:, preload_scope: nil)
       return jit_preload_scoped_relations[name] if jit_preload_scoped_relations&.key?(name)
 
+      base_association = base_association.to_sym
       records = jit_preloader&.records || [self]
       previous_association_values = {}
 
@@ -55,6 +56,7 @@ module JitPreloadExtension
     def preload_scoped_relation(name:, base_association:, preload_scope: nil)
       return jit_preload_scoped_relations[name] if jit_preload_scoped_relations&.key?(name)
 
+      base_association = base_association.to_sym
       records = jit_preloader&.records || [self]
       previous_association_values = {}
 

--- a/lib/jit_preloader/version.rb
+++ b/lib/jit_preloader/version.rb
@@ -1,3 +1,3 @@
 module JitPreloader
-  VERSION = "3.0.0"
+  VERSION = "3.1.0"
 end

--- a/spec/lib/jit_preloader/active_record/base_spec.rb
+++ b/spec/lib/jit_preloader/active_record/base_spec.rb
@@ -106,5 +106,27 @@ RSpec.describe "ActiveRecord::Base Extensions" do
         expect(value).to eq([])
       end
     end
+
+    context "when preload_scoped_relation with string base_association name" do
+      it "preload properly" do
+        contacts = Contact.jit_preload.limit(2).to_a
+
+        call_with_string = lambda { |contact| contact.preload_scoped_relation(
+          name: "American Addresses",
+          base_association: "addresses",
+          preload_scope: Address.where(country: usa)
+        ) }
+
+        usa_addresses = contacts.first.addresses.where(country: usa).to_a
+        expect do
+          expect(call_with_string.call(contacts.first)).to match_array usa_addresses
+        end.to make_database_queries(count: 1)
+
+        usa_addresses = contacts.last.addresses.where(country: usa).to_a
+        expect do
+          expect(call_with_string.call(contacts.last)).to match_array usa_addresses
+        end.to_not make_database_queries
+      end
+    end
   end
 end


### PR DESCRIPTION
During testing to upgrade Manage to latest jit_preloader(3.0.0, [build](https://buildkite.com/clio/manage/builds/263631)) I found that there's some places we use string as `base_association` name when calling `preload_scoped_relation` method([example](https://github.com/clio/themis/blob/7aeda8e18945472f8f966ff59de2c11cd07757e5/components/manage/app/serializers/manage/api/v4/text_message_conversation_serializer.rb#L94-L98)). 

With the latest version, this is causing the error of not able to find the association and properly(ActiveRecord native method of finding association is only allow passing a symbol of association name [reference](https://github.com/clio/jit_preloader/blob/95d99bfd87a435e5e89e065aa9b0a6e9149b5c27/lib/jit_preloader/active_record/base.rb#L64)) and therefore not caching the preload successfully.

The previous version that Manage currently use(1.0.4) also has the same bug but due to the difference ways of assigning preload values to the cache(Unfortunately, ActiveRecord has different behaviour between fetching an association and preload one), the problem is minor and not obvious.

This PR is doing a simple fix of ensuring the `base_association` is a symbol before fetching the owner object association.

Take a look at this [build](https://buildkite.com/clio/manage/builds/263791) which all tests are passing when using [this PR branch jit_preloader version](https://github.com/clio/themis/compare/master...upgrade_jit_preloader_to_3_0_0). 